### PR TITLE
Add pull request preview workflow with checkout

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,31 @@
+name: PR Preview
+
+on:
+  pull_request:
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build site
+        env:
+          SITE_URL: ${{ secrets.SITE_URL }}
+        run: python scripts/build.py
+
+      - name: Deploy Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist


### PR DESCRIPTION
## Summary
- add workflow for preview builds on pull requests
- ensure repository is checked out before deploying preview

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_689d95ce0044832193ef08589b29a535