### PR TITLE
Add cookie banner with Google Analytics consent

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1,4 +1,4 @@
-// ui-version:2025-08-11-v5 – Menü-Overlay & Tooltip Toggle (inline neben Titel)
+// ui-version:2025-08-11-v8 – Menü-Overlay, Tooltip Toggle, Cookie-Banner & GA
 (function(){
   // Menü
   var btn = document.getElementById('nav-toggle');
@@ -31,4 +31,35 @@
       if (openBadge){ openBadge.setAttribute('aria-expanded','false'); }
     }
   });
+
+  // Cookie-Banner & Google Analytics
+  var gaId = window.GA_TRACKING_ID;
+  function loadAnalytics(){
+    if(!gaId) return;
+    var s1 = document.createElement('script');
+    s1.src = 'https://www.googletagmanager.com/gtag/js?id=' + gaId;
+    s1.async = true;
+    document.head.appendChild(s1);
+    var s2 = document.createElement('script');
+    s2.innerHTML = "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '" + gaId + "');";
+    document.head.appendChild(s2);
+  }
+  var consent = localStorage.getItem('ga_consent');
+  var banner = document.getElementById('cookie-banner');
+  var accept = document.getElementById('cookie-accept');
+  var reject = document.getElementById('cookie-reject');
+  if(consent === 'granted'){
+    loadAnalytics();
+  }else if(banner){
+    banner.classList.remove('hidden');
+    if(accept) accept.addEventListener('click', function(){
+      localStorage.setItem('ga_consent','granted');
+      banner.classList.add('hidden');
+      loadAnalytics();
+    });
+    if(reject) reject.addEventListener('click', function(){
+      localStorage.setItem('ga_consent','denied');
+      banner.classList.add('hidden');
+    });
+  }
 })();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-/* ui-version:2025-08-11-v6 – Offer images, accessory label, stable cards */
+/* ui-version:2025-08-11-v8 – Cookie-Banner & Google Analytics */
 :root{
   --bg:#ffffff;
   --panel:#ffffff;
@@ -108,6 +108,12 @@ a:hover{text-decoration:underline}
 .site-footer{border-top:1px solid var(--border);margin-top:18px;background:var(--panel)}
 .footer-inner{padding:20px 16px}
 .muted{color:var(--muted)}
+
+.cookie-banner{position:fixed;bottom:0;left:0;right:0;background:var(--panel);border-top:1px solid var(--border);padding:14px 16px;display:flex;flex-wrap:wrap;gap:12px;align-items:center;z-index:70}
+.cookie-banner p{margin:0;flex:1}
+.cookie-banner button{background:var(--brand);color:#fff;border:none;border-radius:8px;padding:8px 12px;font-weight:700;cursor:pointer}
+.cookie-banner button+button{background:transparent;color:var(--text);margin-left:8px;border:1px solid var(--border)}
+.hidden{display:none}
 
 @media (prefers-reduced-motion: reduce){
   *{scroll-behavior:auto !important;animation:none !important;transition:none !important}

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- ui-version:2025-08-11-v5 -->
+<!-- ui-version:2025-08-11-v8 -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
@@ -7,8 +7,8 @@
   <title>{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar</title>
   {% if meta_description %}<meta name="description" content="{{ meta_description|e }}">{% endif %}
   <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-11-v5" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v5">
+  <link rel="preload" href="/styles.css?v=2025-08-11-v8" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v8">
   {% if canonical %}<link rel="canonical" href="{{ canonical }}">{% endif %}
   <meta property="og:type" content="website">
   <meta property="og:title" content="{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar">
@@ -46,6 +46,15 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-11-v5" defer></script>
+  <div id="cookie-banner" class="cookie-banner hidden">
+    <p>Wir verwenden Cookies, um anonyme Nutzungsstatistiken zu erfassen.</p>
+    <div>
+      <button id="cookie-accept">Akzeptieren</button>
+      <button id="cookie-reject">Ablehnen</button>
+    </div>
+  </div>
+
+  <script>window.GA_TRACKING_ID = 'G-XXXXXXXXXX';</script>
+  <script src="/main.js?v=2025-08-11-v8" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add layout markup for cookie banner and inject Google Analytics script after consent
- wire up banner logic in main.js and load GA only when approved
- style banner and expose utility class for hiding

## Testing
- `python scripts/build.py`
- `ls dist | head`


------
https://chatgpt.com/codex/tasks/task_e_689dffe764ec83219d5595e3e9bbb135