### PR TITLE
Add cookie banner and Google Analytics

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Rewrite absolute asset links to SITE_URL
         run: |
           BASE="https://brettspielpreisradar.de/"
-          find dist -name "*.html" -print0 | xargs -0 sed -i -E 's|(href|src)="/|\1="'"$BASE"'|g'
+          find dist -name "*.html" -print0 | xargs -0 sed -i -E 's#(href|src)="/#\1="'"$BASE"'#g'
 
       # <base> setzen, damit relative Pfade stimmen
       - name: Inject <base> href

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -77,4 +77,5 @@ jobs:
           cname: brettspielpreisradar.de
 
       - name: Show live URL
-        run: echo "Live: https://brettspielpreisradar.de/" >> $GITHUB_STEP_SUMMARY
+        run: |
+          echo "Live: https://brettspielpreisradar.de/" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         run: |
           BASE="https://dom8888912.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/"
-          find dist -name "*.html" -print0 | xargs -0 sed -i -E 's|(href|src)="/|\1="'"$BASE"'|g'
+          find dist -name "*.html" -print0 | xargs -0 sed -i -E 's#(href|src)="/#\1="'"$BASE"'#g'
 
       # <base> setzen, damit relative Pfade stimmen
       - name: Inject <base> href for preview

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -9,9 +9,31 @@
   <meta name="theme-color" content="#ffffff">
   <link rel="preload" href="/styles.css?v=2025-08-11-v5" as="style">
   <link rel="stylesheet" href="/styles.css?v=2025-08-11-v5">
+  <script>
+    function loadAnalytics(){
+      if(window.gaLoaded) return;
+      var s=document.createElement('script');
+      s.async=true;
+      s.src='https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX';
+      document.head.appendChild(s);
+      window.dataLayer=window.dataLayer||[];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js',new Date());
+      gtag('config','G-XXXXXXXXXX');
+      window.gaLoaded=true;
+    }
+    if(localStorage.getItem('cookie-consent')==='accepted'){
+      document.documentElement.classList.add('cookies-accepted');
+      loadAnalytics();
+    }
+  </script>
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
+    <span>Diese Seite nutzt Cookies für Google Analytics.</span>
+    <button id="cookie-accept" type="button">OK</button>
+  </div>
   <header class="site-header" role="banner">
     <div class="container header-inner">
       <a href="/" class="brand">
@@ -52,3 +74,4 @@
   <script src="/main.js?v=2025-08-11-v5" defer></script>
 </body>
 </html>
+

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -8,9 +8,31 @@
   <meta name="theme-color" content="#ffffff">
   <link rel="preload" href="/styles.css?v=2025-08-11-v5" as="style">
   <link rel="stylesheet" href="/styles.css?v=2025-08-11-v5">
+  <script>
+    function loadAnalytics(){
+      if(window.gaLoaded) return;
+      var s=document.createElement('script');
+      s.async=true;
+      s.src='https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX';
+      document.head.appendChild(s);
+      window.dataLayer=window.dataLayer||[];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js',new Date());
+      gtag('config','G-XXXXXXXXXX');
+      window.gaLoaded=true;
+    }
+    if(localStorage.getItem('cookie-consent')==='accepted'){
+      document.documentElement.classList.add('cookies-accepted');
+      loadAnalytics();
+    }
+  </script>
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
+    <span>Diese Seite nutzt Cookies für Google Analytics.</span>
+    <button id="cookie-accept" type="button">OK</button>
+  </div>
   <header class="site-header" role="banner">
     <div class="container header-inner">
       <a href="/" class="brand">
@@ -49,3 +71,4 @@
   <script src="/main.js?v=2025-08-11-v5" defer></script>
 </body>
 </html>
+

--- a/public/main.js
+++ b/public/main.js
@@ -31,4 +31,16 @@
       if (openBadge){ openBadge.setAttribute('aria-expanded','false'); }
     }
   });
+
+  // Cookie Banner
+  var banner = document.getElementById('cookie-banner');
+  var accept = document.getElementById('cookie-accept');
+  if (banner && accept){
+    accept.addEventListener('click', function(){
+      localStorage.setItem('cookie-consent','accepted');
+      document.documentElement.classList.add('cookies-accepted');
+      banner.style.display='none';
+      if (typeof loadAnalytics === 'function'){ loadAnalytics(); }
+    });
+  }
 })();

--- a/public/styles.css
+++ b/public/styles.css
@@ -109,6 +109,10 @@ a:hover{text-decoration:underline}
 .footer-inner{padding:20px 16px}
 .muted{color:var(--muted)}
 
+.cookie-banner{position:fixed;top:0;left:0;right:0;z-index:1000;background:var(--badge);color:var(--badge-text);padding:12px 16px;display:flex;justify-content:center;align-items:center;gap:12px;font-size:.9rem}
+.cookie-banner button{background:var(--brand);color:#fff;border:none;border-radius:8px;padding:6px 12px;cursor:pointer}
+.cookies-accepted .cookie-banner{display:none}
+
 @media (prefers-reduced-motion: reduce){
   *{scroll-behavior:auto !important;animation:none !important;transition:none !important}
 }

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -14,9 +14,31 @@
   <meta property="og:title" content="{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar">
   {% if meta_description %}<meta property="og:description" content="{{ meta_description|e }}">{% endif %}
   <meta property="og:url" content="{{ canonical or site_url }}">
+  <script>
+    function loadAnalytics(){
+      if(window.gaLoaded) return;
+      var s=document.createElement('script');
+      s.async=true;
+      s.src='https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX';
+      document.head.appendChild(s);
+      window.dataLayer=window.dataLayer||[];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js',new Date());
+      gtag('config','G-XXXXXXXXXX');
+      window.gaLoaded=true;
+    }
+    if(localStorage.getItem('cookie-consent')==='accepted'){
+      document.documentElement.classList.add('cookies-accepted');
+      loadAnalytics();
+    }
+  </script>
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
+    <span>Diese Seite nutzt Cookies für Google Analytics.</span>
+    <button id="cookie-accept" type="button">OK</button>
+  </div>
   <header class="site-header" role="banner">
     <div class="container header-inner">
       <a href="/" class="brand">
@@ -49,3 +71,4 @@
   <script src="/main.js?v=2025-08-11-v5" defer></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add global cookie banner with consent handling
- integrate Google Analytics loading after consent
- style and script banner and analytics across static pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/build.py`
- `ls dist | head`


------
https://chatgpt.com/codex/tasks/task_e_68a06eeb26dc8321a0b26700f46db360