### PR TITLE
Add missing logo asset

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28">
+  <rect width="28" height="28" rx="4" fill="#4b0082"/>
+  <text x="14" y="20" text-anchor="middle" font-size="18" fill="#fff" font-family="Arial" font-weight="bold">B</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add `public/logo.svg` so the site header logo loads correctly.

## Testing
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68a07b7429b88321acbcc1f30e22ecca