### PR TITLE
Add news tab and highlight eBay offer links

### DIFF
--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- ui-version:2025-08-11-v7 -->
+<!-- ui-version:2025-08-11-v8 -->
 <!-- Test-Preview -->
 <html lang="de">
 <head>
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Datenschutz – Brettspiel Preisradar</title>
   <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-11-v7" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v7">
+  <link rel="preload" href="/styles.css?v=2025-08-11-v8" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v8">
   <script>
     function loadAnalytics(){
       if(window.gaLoaded) return;
@@ -34,11 +34,11 @@
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
-    <p>Wir verwenden Cookies, um anonyme Nutzungsstatistiken (Google Analytics) zu sammeln. Du kannst zustimmen oder ablehnen.</p>
+    <p>Wir nutzen die eBay API zur Darstellung von Angeboten (technisch notwendig). Für Statistik (Google API) und Affiliate-Links (eBay Partner Network) setzen wir Cookies nur nach deiner Einwilligung. Weitere Infos in der <a href="/datenschutz">Datenschutzerklärung</a>. Deine Einwilligung kannst du jederzeit in den <a href="/datenschutz#cookie-einstellungen" class="cookie-settings-link">Cookie-Einstellungen</a> anpassen.</p>
     <div class="cookie-actions">
       <button id="cookie-accept" type="button">Alle akzeptieren</button>
-      <button id="cookie-decline" type="button" class="btn-decline">Ablehnen</button>
-      <a href="/datenschutz.html" class="cookie-more">Mehr Infos</a>
+      <button id="cookie-decline" type="button" class="btn-decline">Nur notwendige Cookies</button>
+      <button id="cookie-settings" type="button" class="btn-decline" onclick="location.href='/datenschutz#cookie-einstellungen'">Einstellungen</button>
     </div>
   </div>
   <header class="site-header" role="banner">
@@ -49,10 +49,11 @@
       </a>
       <button id="nav-toggle" class="nav-toggle" aria-label="Menü öffnen" aria-controls="main-nav" aria-expanded="false" aria-haspopup="true">☰</button>
       <nav id="main-nav" class="main-nav" role="navigation" aria-label="Hauptmenü">
-        <a href="/">Start</a>
+        <a href="/">Alle Spiele</a>
+        <a href="/neuigkeiten.html">Neuigkeiten</a>
         <a href="/hubs.html">Themen</a>
         <a href="/impressum.html">Impressum</a>
-        <a href="/datenschutz.html">Datenschutz</a>
+        <a href="/datenschutz">Datenschutz</a>
       </nav>
     </div>
   </header>
@@ -61,12 +62,22 @@
 
     <article class="content-section">
       <h1 class="h2">Datenschutz</h1>
-      <p>Wir verwenden Google Analytics, um anonyme Nutzungsstatistiken zu erheben. Die Cookies werden nur gesetzt, wenn du über den Banner zustimmst. Serverseitige Logfiles werden automatisch vom Hoster erhoben.</p>
-      <ul>
-        <li>Verantwortlicher: [Dein Name/Firma], kontakt@brettspielpreisradar.de</li>
-        <li>Affiliate-Links: Beim Klick gelten die Datenschutzbestimmungen des jeweiligen Shops (z.&nbsp;B. eBay).</li>
-      </ul>
-      <p class="muted">Passe diesen Text an deine tatsächliche Situation an.</p>
+      <p>Es gibt keine Logins oder eigenen Formulare. Wir speichern keine personenbezogenen Daten.</p>
+      <h2>Verantwortlicher</h2>
+      <p>[Name/Firma]<br>[Straße, PLZ Ort, Land]<br>E-Mail: <a href="mailto:[E-Mail]">[E-Mail]</a></p>
+      <h2>Eingesetzte Dienste</h2>
+      <h3>Technisch notwendige Dienste</h3>
+      <p>eBay API – zur Darstellung von Angeboten. Dieser Dienst ist erforderlich, damit die Website funktioniert und setzt keine Cookies.</p>
+      <h3>Optionale Dienste (nur mit Einwilligung)</h3>
+      <p>eBay Partner Network (EPN) – Affiliate-/Tracking-Cookies zur Vergütung unserer Links.</p>
+      <p>Google API – anonyme Statistik.</p>
+      <h2 id="cookie-einstellungen">Cookie-Einstellungen</h2>
+      <p>Du kannst deine Einwilligung jederzeit ändern:</p>
+      <div class="cookie-actions">
+        <button id="settings-accept" type="button">Alle akzeptieren</button>
+        <button id="settings-decline" type="button" class="btn-decline">Nur notwendige Cookies</button>
+      </div>
+      <p id="consent-status" class="consent-status" role="status" aria-live="polite"></p>
     </article>
 
   </main>
@@ -78,7 +89,7 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-11-v7" defer></script>
+  <script src="/main.js?v=2025-08-11-v8" defer></script>
 </body>
 </html>
 

--- a/public/ebay.svg
+++ b/public/ebay.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 20" role="img" aria-label="eBay">
+  <text y="15" font-family="Arial, sans-serif" font-size="14" font-weight="700">
+    <tspan fill="#e53238">e</tspan>
+    <tspan fill="#0064d2" x="18">b</tspan>
+    <tspan fill="#f5af02" x="36">a</tspan>
+    <tspan fill="#86b817" x="54">y</tspan>
+  </text>
+</svg>

--- a/public/main.js
+++ b/public/main.js
@@ -1,4 +1,4 @@
-// ui-version:2025-08-11-v7 – Menü-Overlay, Tooltip Toggle, Cookie-Banner mit Ablehnen
+// ui-version:2025-08-11-v8 – Menü-Overlay, Tooltip Toggle, Suche & Cookie-Banner unten
 (function(){
   // Menü
   var btn = document.getElementById('nav-toggle');
@@ -32,21 +32,55 @@
     }
   });
 
+  // Suche
+  var q = document.getElementById('q');
+  var list = document.querySelector('[data-list]');
+  if (q && list){
+    q.addEventListener('input', function(){
+      var term = q.value.toLowerCase();
+      list.querySelectorAll('li').forEach(function(li){
+        li.style.display = li.textContent.toLowerCase().indexOf(term) === -1 ? 'none' : '';
+      });
+    });
+  }
+
   // Cookie Banner
   var banner = document.getElementById('cookie-banner');
   var accept = document.getElementById('cookie-accept');
   var decline = document.getElementById('cookie-decline');
-  if (banner && accept && decline){
-    accept.addEventListener('click', function(){
-      localStorage.setItem('cookie-consent','accepted');
-      document.documentElement.classList.add('cookies-accepted');
-      banner.style.display='none';
-      if (typeof loadAnalytics === 'function'){ loadAnalytics(); }
-    });
-    decline.addEventListener('click', function(){
-      localStorage.setItem('cookie-consent','declined');
-      document.documentElement.classList.add('cookies-declined');
-      banner.style.display='none';
-    });
+  var settingsAccept = document.getElementById('settings-accept');
+  var settingsDecline = document.getElementById('settings-decline');
+  var status = document.getElementById('consent-status');
+
+  function showStatus(msg){
+    if (status){
+      status.textContent = msg;
+      status.style.display = 'block';
+      setTimeout(function(){ status.style.display='none'; }, 3000);
+    }
   }
+
+  function consentAccept(){
+    localStorage.setItem('cookie-consent','accepted');
+    document.documentElement.classList.add('cookies-accepted');
+    if (banner) banner.style.display='none';
+    if (typeof loadAnalytics === 'function'){ loadAnalytics(); }
+  }
+
+  function consentDecline(){
+    localStorage.setItem('cookie-consent','declined');
+    document.documentElement.classList.add('cookies-declined');
+    if (banner) banner.style.display='none';
+  }
+
+  if (accept) accept.addEventListener('click', consentAccept);
+  if (decline) decline.addEventListener('click', consentDecline);
+  if (settingsAccept) settingsAccept.addEventListener('click', function(){
+    consentAccept();
+    showStatus('Einstellungen gespeichert.');
+  });
+  if (settingsDecline) settingsDecline.addEventListener('click', function(){
+    consentDecline();
+    showStatus('Einstellungen gespeichert.');
+  });
 })();

--- a/public/neuigkeiten.html
+++ b/public/neuigkeiten.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Impressum – Brettspiel Preisradar</title>
+  <title>Neuigkeiten – Brettspiel Preisradar</title>
   <meta name="theme-color" content="#ffffff">
   <link rel="preload" href="/styles.css?v=2025-08-11-v8" as="style">
   <link rel="stylesheet" href="/styles.css?v=2025-08-11-v8">
@@ -16,7 +16,7 @@
       s.src='https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX';
       document.head.appendChild(s);
       window.dataLayer=window.dataLayer||[];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag(){dataLayer.push(arguments);} 
       gtag('js',new Date());
       gtag('config','G-XXXXXXXXXX');
       window.gaLoaded=true;
@@ -58,15 +58,10 @@
   </header>
 
   <main id="main" class="container">
-
     <article class="content-section">
-      <h1 class="h2">Impressum</h1>
-      <p><strong>Verantwortlich:</strong><br> [Dein Name/Firma]<br> [Straße Nr.]<br> [PLZ Ort]<br> [Land]</p>
-      <p><strong>Kontakt:</strong><br> E-Mail: kontakt@brettspielpreisradar.de</p>
-      <p><strong>Haftung für Inhalte/Links:</strong> Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für Inhalte externer Links.</p>
-      <p class="muted">Passe diese Angaben an deine tatsächlichen Daten an.</p>
+      <h1 class="h2">Neuigkeiten</h1>
+      <p>Hier entsteht bald ein Blog mit KI-generierten News rund um die Brettspielwelt.</p>
     </article>
-
   </main>
 
   <footer class="site-footer" role="contentinfo">
@@ -79,4 +74,3 @@
   <script src="/main.js?v=2025-08-11-v8" defer></script>
 </body>
 </html>
-

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-/* ui-version:2025-08-11-v7 – Cookie-Banner mit Auswahl, Offer images, accessory label, stable cards */
+/* ui-version:2025-08-11-v8 – Cookie-Banner mit Auswahl, Suche & Skip-Link Fix */
 :root{
   --bg:#ffffff;
   --panel:#ffffff;
@@ -26,6 +26,9 @@ body{margin:0;background:var(--bg);color:var(--text);font:16px/1.65 system-ui,-a
 a{color:#0369a1;text-decoration:none}
 a:hover{text-decoration:underline}
 :focus-visible{outline:3px solid var(--focus);outline-offset:2px;border-radius:6px}
+
+.skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden}
+.skip-link:focus{left:10px;top:10px;width:auto;height:auto;overflow:visible;padding:8px 12px;background:var(--brand);color:#fff;border-radius:8px;z-index:1000}
 
 .container{max-width:980px;margin:0 auto;padding:16px}
 .site-header{background:var(--panel);border-bottom:1px solid var(--border);position:sticky;top:0;z-index:40}
@@ -76,6 +79,14 @@ a:hover{text-decoration:underline}
 .btn-secondary{background:#0ea5e9;color:white;width:100%}
 .btn-secondary:hover{opacity:.95}
 .btn-link{color:#0369a1}
+.offer-link{display:inline-flex;align-items:center;gap:6px}
+.offer-logo{width:20px;height:auto}
+.search{margin:20px 0}
+.search input{width:100%;padding:14px 16px;border:1px solid var(--border);border-radius:12px;font-size:1.05rem}
+.game-list{list-style:none;padding:0;margin:0}
+.game-list li{margin:6px 0}
+.game-list a{display:block;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);color:var(--text);text-decoration:none}
+.game-list a:hover{background:#f8fafc}
 @media (min-width:720px){ .btn-primary,.btn-secondary{width:auto} }
 
 .checklist{list-style:disc;padding-left:20px;margin:0}
@@ -109,13 +120,15 @@ a:hover{text-decoration:underline}
 .footer-inner{padding:20px 16px}
 .muted{color:var(--muted)}
 
-.cookie-banner{position:fixed;top:0;left:0;right:0;z-index:1000;background:#fff;color:var(--text);border-bottom:1px solid var(--border);box-shadow:var(--shadow);padding:12px 16px;display:flex;flex-direction:column;align-items:center;gap:12px;font-size:.9rem;text-align:center}
+.cookie-banner{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:#fff;color:var(--text);border-top:1px solid var(--border);box-shadow:var(--shadow);padding:12px 16px;display:flex;flex-direction:column;align-items:center;gap:12px;font-size:.9rem;text-align:center}
 .cookie-banner .cookie-actions{display:flex;flex-wrap:wrap;gap:8px;justify-content:center;align-items:center}
 .cookie-banner button{border:none;border-radius:8px;padding:6px 12px;cursor:pointer;font-weight:600}
-#cookie-accept{background:var(--brand);color:#fff}
-#cookie-decline{background:#e2e8f0;color:var(--text)}
-.cookie-banner .cookie-more{color:#0369a1;font-size:.85rem}
+#cookie-accept,#settings-accept{background:var(--brand);color:#fff}
+#cookie-decline,#settings-decline,#cookie-settings{background:#e2e8f0;color:var(--text)}
+.cookie-banner .cookie-more,.cookie-banner .cookie-settings-link{color:#0369a1;font-size:.85rem}
 .cookies-accepted .cookie-banner,.cookies-declined .cookie-banner{display:none}
+
+.consent-status{margin-top:10px;font-size:.9rem;color:var(--brand);display:none;text-align:center}
 
 @media (prefers-reduced-motion: reduce){
   *{scroll-behavior:auto !important;animation:none !important;transition:none !important}

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -1,7 +1,7 @@
-<h1>Brettspiel-Preisradar</h1>
-<p>Aktuelle Angebote & Preisindikator für Brettspiele. Nutze die Suche:</p>
-<div class="search"><input id="q" type="search" placeholder="Spiel suchen …"></div>
-<ul data-list>
+<h1>Alle Spiele</h1>
+<p>Aktuelle Angebote &amp; Preisindikator für Brettspiele. Nutze die Suche:</p>
+<div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
+<ul class="game-list" data-list>
 {% for g in games %}
   <li><a href="/spiel/{{ g.slug }}/">{{ g.title }}</a></li>
 {% endfor %}

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- ui-version:2025-08-11-v7 -->
+<!-- ui-version:2025-08-11-v8 -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
@@ -7,8 +7,8 @@
   <title>{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar</title>
   {% if meta_description %}<meta name="description" content="{{ meta_description|e }}">{% endif %}
   <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-11-v7" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v7">
+  <link rel="preload" href="/styles.css?v=2025-08-11-v8" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v8">
   {% if canonical %}<link rel="canonical" href="{{ canonical }}">{% endif %}
   <meta property="og:type" content="website">
   <meta property="og:title" content="{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar">
@@ -39,12 +39,11 @@
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
-
-    <p>Wir verwenden Cookies, um anonyme Nutzungsstatistiken (Google Analytics) zu sammeln. Du kannst zustimmen oder ablehnen.</p>
+    <p>Wir nutzen die eBay API zur Darstellung von Angeboten (technisch notwendig). Für Statistik (Google API) und Affiliate-Links (eBay Partner Network) setzen wir Cookies nur nach deiner Einwilligung. Weitere Infos in der <a href="/datenschutz">Datenschutzerklärung</a>. Deine Einwilligung kannst du jederzeit in den <a href="/datenschutz#cookie-einstellungen" class="cookie-settings-link">Cookie-Einstellungen</a> anpassen.</p>
     <div class="cookie-actions">
       <button id="cookie-accept" type="button">Alle akzeptieren</button>
-      <button id="cookie-decline" type="button" class="btn-decline">Ablehnen</button>
-      <a href="/datenschutz.html" class="cookie-more">Mehr Infos</a>
+      <button id="cookie-decline" type="button" class="btn-decline">Nur notwendige Cookies</button>
+      <button id="cookie-settings" type="button" class="btn-decline" onclick="location.href='/datenschutz#cookie-einstellungen'">Einstellungen</button>
     </div>
   </div>
   <header class="site-header" role="banner">
@@ -57,10 +56,11 @@
         ☰
       </button>
       <nav id="main-nav" class="main-nav" role="navigation" aria-label="Hauptmenü">
-        <a href="/">Start</a>
+        <a href="/">Alle Spiele</a>
+        <a href="/neuigkeiten.html">Neuigkeiten</a>
         <a href="/hubs.html">Themen</a>
         <a href="/impressum.html">Impressum</a>
-        <a href="/datenschutz.html">Datenschutz</a>
+        <a href="/datenschutz">Datenschutz</a>
       </nav>
     </div>
   </header>
@@ -76,7 +76,7 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-11-v7" defer></script>
+  <script src="/main.js?v=2025-08-11-v8" defer></script>
 </body>
 </html>
 

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -1,7 +1,7 @@
 {# ui-version:2025-08-11-v6 #}
 <article class="page">
   <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href="/">Start</a> <span aria-hidden="true">›</span>
+    <a href="/">Alle Spiele</a> <span aria-hidden="true">›</span>
     <a href="/hubs.html">Brettspiele</a> <span aria-hidden="true">›</span>
     <span aria-current="page">{{ game.title }}</span>
   </nav>
@@ -45,7 +45,7 @@
       <p class="muted">Für dieses Spiel haben wir noch keine Preisschwellen hinterlegt.</p>
     {% endif %}
     <div class="cta-row">
-      <a class="btn btn-primary" href="#angebote">Jetzt Angebote ansehen</a>
+      <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
     </div>
   </section>
 
@@ -111,7 +111,9 @@
               <span class="price">{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }} €{% else %}–{% endif %}</span>
               {% if o.condition %}<span class="condition">{{ o.condition }}</span>{% endif %}
             </div>
-            <a class="btn btn-secondary" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a>
+            <a class="btn btn-secondary offer-link" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">
+              {% if 'ebay' in o.url %}<img src="/ebay.svg" alt="" class="offer-logo"> Zum Angebot auf eBay{% else %}Zum Angebot{% endif %}
+            </a>
           </article>
         {% endfor %}
       </div>
@@ -166,7 +168,7 @@
   {% endif %}
 
   <section class="content-section">
-    <a class="btn btn-link" href="/">← Zur Übersicht</a>
+    <a class="btn btn-link" href="/">← Alle Spiele</a>
   </section>
 
   {% set prices = (offers | map(attribute='price_eur') | reject('equalto', None) | list) if offers else [] %}


### PR DESCRIPTION
## Summary
- rename navigation to "Alle Spiele" and add a new "Neuigkeiten" page
- enlarge the game search field and refine the list UI
- show an eBay logo on offer buttons and keep "Jetzt Angebote ansehen" on-page

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a09c021b1c8321a13b50f16d857b43