### PR TITLE
Add filters for players, age and themes

### DIFF
--- a/content/games/azul.yaml
+++ b/content/games/azul.yaml
@@ -1,6 +1,10 @@
 slug: azul
 title: Azul – Preisradar & Angebote
 players: 2–4
+age: 8
+themes:
+- Abstrakt
+- Puzzle
 playtime_minutes: 30–45
 weight: 1.8
 year: 2017

--- a/content/games/catan.yaml
+++ b/content/games/catan.yaml
@@ -1,6 +1,11 @@
 slug: catan
 title: CATAN – Preisradar & Angebote
 players: 3–4
+age: 10
+themes:
+- Handel
+- Siedeln
+- Strategie
 playtime_minutes: 60–120
 weight: 2.3
 year: 1995

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -33,6 +33,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-overlay" class="cookie-overlay"></div>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
     <p>Wir nutzen die eBay API zur Darstellung von Angeboten (technisch notwendig). Für Statistik (Google API) und Affiliate-Links (eBay Partner Network) setzen wir Cookies nur nach deiner Einwilligung. Weitere Infos in der <a href="/datenschutz">Datenschutzerklärung</a>. Deine Einwilligung kannst du jederzeit in den <a href="/datenschutz#cookie-einstellungen" class="cookie-settings-link">Cookie-Einstellungen</a> anpassen.</p>
     <div class="cookie-actions">

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -32,6 +32,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-overlay" class="cookie-overlay"></div>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
     <p>Wir nutzen die eBay API zur Darstellung von Angeboten (technisch notwendig). Für Statistik (Google API) und Affiliate-Links (eBay Partner Network) setzen wir Cookies nur nach deiner Einwilligung. Weitere Infos in der <a href="/datenschutz">Datenschutzerklärung</a>. Deine Einwilligung kannst du jederzeit in den <a href="/datenschutz#cookie-einstellungen" class="cookie-settings-link">Cookie-Einstellungen</a> anpassen.</p>
     <div class="cookie-actions">

--- a/public/main.js
+++ b/public/main.js
@@ -32,17 +32,42 @@
     }
   });
 
-  // Suche
+  // Suche & Filter
   var q = document.getElementById('q');
   var list = document.querySelector('[data-list]');
-  if (q && list){
-    q.addEventListener('input', function(){
-      var term = q.value.toLowerCase();
-      list.querySelectorAll('li').forEach(function(li){
-        li.style.display = li.textContent.toLowerCase().indexOf(term) === -1 ? 'none' : '';
-      });
+  var pFilter = document.getElementById('filter-players');
+  var aFilter = document.getElementById('filter-age');
+  var tFilter = document.getElementById('filter-theme');
+
+  function applyFilters(){
+    if (!list) return;
+    var term = q ? q.value.toLowerCase() : '';
+    var players = pFilter && pFilter.value ? parseInt(pFilter.value,10) : null;
+    var age = aFilter && aFilter.value ? parseInt(aFilter.value,10) : null;
+    var theme = tFilter && tFilter.value ? tFilter.value : null;
+    list.querySelectorAll('li').forEach(function(li){
+      var textMatch = !term || li.textContent.toLowerCase().indexOf(term) !== -1;
+      var pMatch = true;
+      var aMatch = true;
+      var tMatch = true;
+      if (players){
+        var min = parseInt(li.dataset.minPlayers,10);
+        var max = parseInt(li.dataset.maxPlayers,10);
+        if (min && max){ pMatch = players >= min && players <= max; }
+      }
+      if (age){
+        var gAge = parseInt(li.dataset.age,10);
+        if (gAge){ aMatch = gAge <= age; }
+      }
+      if (theme){
+        var themes = li.dataset.themes ? li.dataset.themes.split(',') : [];
+        tMatch = themes.indexOf(theme) !== -1;
+      }
+      li.style.display = (textMatch && pMatch && aMatch && tMatch) ? '' : 'none';
     });
   }
+  [q, pFilter, aFilter, tFilter].forEach(function(el){ if (el) el.addEventListener('input', applyFilters); });
+  applyFilters();
 
   // Cookie Banner
   var banner = document.getElementById('cookie-banner');

--- a/public/neuigkeiten.html
+++ b/public/neuigkeiten.html
@@ -32,6 +32,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-overlay" class="cookie-overlay"></div>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
     <p>Wir nutzen die eBay API zur Darstellung von Angeboten (technisch notwendig). Für Statistik (Google API) und Affiliate-Links (eBay Partner Network) setzen wir Cookies nur nach deiner Einwilligung. Weitere Infos in der <a href="/datenschutz">Datenschutzerklärung</a>. Deine Einwilligung kannst du jederzeit in den <a href="/datenschutz#cookie-einstellungen" class="cookie-settings-link">Cookie-Einstellungen</a> anpassen.</p>
     <div class="cookie-actions">

--- a/public/styles.css
+++ b/public/styles.css
@@ -127,6 +127,8 @@ a:hover{text-decoration:underline}
 #cookie-decline,#settings-decline,#cookie-settings{background:#e2e8f0;color:var(--text)}
 .cookie-banner .cookie-more,.cookie-banner .cookie-settings-link{color:#0369a1;font-size:.85rem}
 .cookies-accepted .cookie-banner,.cookies-declined .cookie-banner{display:none}
+.cookie-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);z-index:999}
+.cookies-accepted .cookie-overlay,.cookies-declined .cookie-overlay{display:none}
 
 .consent-status{margin-top:10px;font-size:.9rem;color:var(--brand);display:none;text-align:center}
 

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -1,8 +1,22 @@
 <h1>Alle Spiele</h1>
-<p>Aktuelle Angebote &amp; Preisindikator für Brettspiele. Nutze die Suche:</p>
+<p>Aktuelle Angebote &amp; Preisindikator für Brettspiele. Nutze Suche oder Filter:</p>
 <div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
+<div class="filters">
+  <label>Spieler <input id="filter-players" type="number" min="1" placeholder="z. B. 4"></label>
+  <label>Alter <input id="filter-age" type="number" min="0" placeholder="z. B. 10"></label>
+  {% if themes %}
+  <label>Thema
+    <select id="filter-theme">
+      <option value="">Alle</option>
+      {% for t in themes %}
+      <option value="{{ t }}">{{ t }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  {% endif %}
+</div>
 <ul class="game-list" data-list>
 {% for g in games %}
-  <li><a href="/spiel/{{ g.slug }}/">{{ g.title }}</a></li>
+  <li data-min-players="{{ g.min_players }}" data-max-players="{{ g.max_players }}" data-age="{{ g.age if g.age is not none else '' }}" data-themes="{{ g.themes|join(',') }}"><a href="/spiel/{{ g.slug }}/">{{ g.title_short }}</a></li>
 {% endfor %}
 </ul>

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -38,6 +38,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Zum Inhalt springen</a>
+  <div id="cookie-overlay" class="cookie-overlay"></div>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite">
     <p>Wir nutzen die eBay API zur Darstellung von Angeboten (technisch notwendig). Für Statistik (Google API) und Affiliate-Links (eBay Partner Network) setzen wir Cookies nur nach deiner Einwilligung. Weitere Infos in der <a href="/datenschutz">Datenschutzerklärung</a>. Deine Einwilligung kannst du jederzeit in den <a href="/datenschutz#cookie-einstellungen" class="cookie-settings-link">Cookie-Einstellungen</a> anpassen.</p>
     <div class="cookie-actions">


### PR DESCRIPTION
## Summary
- Strip offer suffix from game titles on index page
- Allow filtering games by players, age and theme
- Add missing age/theme metadata for sample games
- Dim page background while cookie banner is visible

## Testing
- `python scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0ae0d86d8832198d564b1f822c434