### PR TITLE
Switch offers to desktop table and improve mobile filters

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -66,8 +66,32 @@
       li.style.display = (textMatch && pMatch && aMatch && tMatch) ? '' : 'none';
     });
   }
-  [q, pFilter, aFilter, tFilter].forEach(function(el){ if (el) el.addEventListener('input', applyFilters); });
+  [q, pFilter, aFilter, tFilter].forEach(function(el){
+    if (el){
+      el.addEventListener('input', applyFilters);
+      el.addEventListener('change', applyFilters);
+    }
+  });
   applyFilters();
+
+  // Angebots-Filter (Zubehör/Neu)
+  var hideAcc = document.getElementById('filter-hide-accessory');
+  var onlyNew = document.getElementById('filter-only-new');
+
+  function applyOfferFilters(){
+    var offers = document.querySelectorAll('[data-offer]');
+    offers.forEach(function(el){
+      var isAcc = el.dataset.accessory === '1';
+      var cond = (el.dataset.condition || '').toLowerCase();
+      var show = true;
+      if (hideAcc && hideAcc.checked && isAcc) show = false;
+      if (onlyNew && onlyNew.checked && cond.indexOf('neu') === -1) show = false;
+      el.style.display = show ? '' : 'none';
+    });
+  }
+
+  [hideAcc, onlyNew].forEach(function(el){ if (el){ el.addEventListener('change', applyOfferFilters); } });
+  applyOfferFilters();
 
   // Cookie Banner
   var banner = document.getElementById('cookie-banner');

--- a/public/styles.css
+++ b/public/styles.css
@@ -82,6 +82,10 @@ a:hover{text-decoration:underline}
 .offer-link{display:inline-flex;align-items:center}
 .search{margin:20px 0}
 .search input{width:100%;padding:14px 16px;border:1px solid var(--border);border-radius:12px;font-size:1.05rem}
+.filters{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0}
+.filters label{display:flex;flex-direction:column;font-size:.95rem;flex:1 1 120px}
+.filters input,.filters select{padding:8px 10px;border:1px solid var(--border);border-radius:8px}
+@media (max-width:480px){ .filters label{flex:1 1 100%} }
 .game-list{list-style:none;padding:0;margin:0}
 .game-list li{margin:6px 0}
 .game-list a{display:block;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);color:var(--text);text-decoration:none}
@@ -91,9 +95,18 @@ a:hover{text-decoration:underline}
 .checklist{list-style:disc;padding-left:20px;margin:0}
 
 .offers-head{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.offer-filters{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0}
+.offer-filters label{display:flex;align-items:center;gap:4px;font-size:.95rem}
 .offer-grid{display:grid;grid-template-columns:1fr;gap:12px}
 @media (min-width:480px){ .offer-grid{grid-template-columns:repeat(2,minmax(0,1fr))} }
 @media (min-width:880px){ .offer-grid{grid-template-columns:repeat(3,minmax(0,1fr))} }
+.offer-table{display:none;width:100%;border-collapse:collapse;margin-top:12px}
+.offer-table th,.offer-table td{border:1px solid var(--border);padding:8px;text-align:left}
+.offer-table tr.top{background:rgba(22,163,74,.08)}
+@media (min-width:880px){
+  .offer-grid{display:none}
+  .offer-table{display:table}
+}
 .offer-card{
   position:relative;background:var(--card);border:1px solid var(--border);border-radius:14px;padding:14px;box-shadow:0 2px 8px rgba(0,0,0,.04);
   display:flex;flex-direction:column;min-height:320px;

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -87,10 +87,15 @@
     </div>
 
     {% if offers and offers|length > 0 %}
+      <div class="offer-filters">
+        <label><input type="checkbox" id="filter-hide-accessory"> Zubehör ausblenden</label>
+        <label><input type="checkbox" id="filter-only-new"> Nur Neu</label>
+      </div>
+
       <div class="offer-grid">
         {% for o in offers %}
           {% set is_top = (good and o.price_eur is number and o.price_eur <= good) %}
-          <article class="offer-card{% if is_top %} top{% endif %}">
+          <article class="offer-card{% if is_top %} top{% endif %}" data-offer data-accessory="{{ '1' if o.is_accessory else '0' }}" data-condition="{{ o.condition|lower if o.condition else '' }}">
             {% if is_top %}<div class="badge">Top-Deal</div>{% endif %}
             {% if o.is_accessory %}<div class="badge badge-grey" title="Zubehör/Erweiterung">Zubehör</div>{% endif %}
             {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
@@ -105,6 +110,32 @@
           </article>
         {% endfor %}
       </div>
+
+      <table class="offer-table">
+        <thead>
+          <tr>
+            <th>Angebot</th>
+            <th>Preis</th>
+            <th>Zustand</th>
+            <th>Zubehör</th>
+            <th>Anbieter</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for o in offers %}
+          {% set is_top = (good and o.price_eur is number and o.price_eur <= good) %}
+          <tr{% if is_top %} class="top"{% endif %} data-offer data-accessory="{{ '1' if o.is_accessory else '0' }}" data-condition="{{ o.condition|lower if o.condition else '' }}">
+            <td>{{ o.title }}</td>
+            <td>{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }} €{% else %}–{% endif %}</td>
+            <td>{{ o.condition or '–' }}</td>
+            <td>{% if o.is_accessory %}Ja{% else %}–{% endif %}</td>
+            <td>{% if 'ebay' in o.url %}eBay{% else %}–{% endif %}</td>
+            <td><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a></td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
     {% else %}
       <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
     {% endif %}


### PR DESCRIPTION
## Summary
- show offer table on desktop with provider, condition and accessory columns
- add mobile offer filters and fix "Alle Spiele" filters

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0b38d84f88321b61c2eecbb5aebd1