### PR TITLE
Fix offer price display and update privacy policy

### DIFF
--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -61,15 +61,63 @@
 
     <article class="content-section">
       <h1 class="h2">Datenschutz</h1>
-      <p>Es gibt keine Logins oder eigenen Formulare. Wir speichern keine personenbezogenen Daten.</p>
-      <h2>Verantwortlicher</h2>
-      <p>[Name/Firma]<br>[Straße, PLZ Ort, Land]<br>E-Mail: <a href="mailto:[E-Mail]">[E-Mail]</a></p>
-      <h2>Eingesetzte Dienste</h2>
-      <h3>Technisch notwendige Dienste</h3>
-      <p>eBay API – zur Darstellung von Angeboten. Dieser Dienst ist erforderlich, damit die Website funktioniert und setzt keine Cookies.</p>
-      <h3>Optionale Dienste (nur mit Einwilligung)</h3>
-      <p>eBay Partner Network (EPN) – Affiliate-/Tracking-Cookies zur Vergütung unserer Links.</p>
-      <p>Google API – anonyme Statistik.</p>
+        <p>Datenschutzerklärung für brettspielpreisradar.de</p>
+        <h2>1. Verantwortlicher</h2>
+        <p>Verantwortlich für die Datenverarbeitung auf dieser Website ist:</p>
+        <p>[Name]<br>[Adresse]<br>[PLZ, Ort]<br>E-Mail: <a href="mailto:[E-Mail-Adresse]">[E-Mail-Adresse]</a></p>
+        <h2>2. Hosting</h2>
+        <p>Diese Website wird über GitHub Pages bereitgestellt, ein Dienst der GitHub Inc., 88 Colin P. Kelly Jr. Street, San Francisco, CA 94107, USA, einem Tochterunternehmen von Microsoft Corporation, One Microsoft Way, Redmond, WA 98052-6399, USA.</p>
+        <p>Beim Aufruf der Website werden durch GitHub automatisch technische Daten wie die IP-Adresse verarbeitet, um die Auslieferung der Website zu ermöglichen. Diese Daten können in die USA übertragen werden.</p>
+        <p>Weitere Informationen:<br><a href="https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement">https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement</a></p>
+        <h2>3. Erhebung und Speicherung personenbezogener Daten</h2>
+        <p>Beim Aufrufen dieser Website werden durch den Browser automatisch Informationen an den Server gesendet. Diese Daten werden temporär in sog. Logfiles gespeichert. Erfasst werden u. a.:</p>
+        <ul>
+          <li>IP-Adresse des Endgeräts</li>
+          <li>Datum und Uhrzeit des Zugriffs</li>
+          <li>Name und URL der abgerufenen Datei</li>
+          <li>Referrer-URL (Website, von der aus der Zugriff erfolgt)</li>
+          <li>verwendeter Browser und Betriebssystem</li>
+        </ul>
+        <p>Die Verarbeitung erfolgt zur Gewährleistung eines reibungslosen Betriebs der Website (Art. 6 Abs. 1 lit. f DSGVO).</p>
+        <h2>4. Cookies &amp; Consent-Management</h2>
+        <p>Diese Website verwendet Cookies.<br>Beim ersten Besuch erscheint ein Cookie-Banner, mit dem Sie Ihre Einwilligung zur Nutzung nicht-technisch notwendiger Cookies (z. B. Google Analytics, Affiliate-Tracking) erteilen oder verweigern können.</p>
+        <p>Rechtsgrundlagen:</p>
+        <ul>
+          <li>technisch notwendige Cookies: Art. 6 Abs. 1 lit. f DSGVO</li>
+          <li>Cookies zu Analyse- oder Marketingzwecken: Art. 6 Abs. 1 lit. a DSGVO</li>
+        </ul>
+        <h2>5. Google Analytics</h2>
+        <p>Diese Website nutzt Google Analytics, einen Webanalysedienst der Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland.</p>
+        <p>Google Analytics verwendet Cookies, die eine Analyse der Nutzung der Website ermöglichen. Die durch Cookies erzeugten Informationen werden in der Regel an Server von Google in den USA übertragen.</p>
+        <p>Es wird die Funktion IP-Anonymisierung eingesetzt, sodass IP-Adressen nur gekürzt verarbeitet werden.</p>
+        <p>Rechtsgrundlage: Ihre Einwilligung (Art. 6 Abs. 1 lit. a DSGVO).<br>Widerruf: Über das Cookie-Banner jederzeit möglich.</p>
+        <h2>6. Einbindung der eBay API und Partnerprogramm</h2>
+        <p>Zur Darstellung von Produktangeboten nutzen wir die eBay API. Dabei werden Daten (z. B. Produktbilder, Preise, Angebote) direkt von eBay geladen.</p>
+        <p>Wir nehmen zudem am eBay Partner Network teil. Bei Klick auf Affiliate-Links können Cookies von eBay gesetzt werden, um die Herkunft einer Bestellung nachzuvollziehen. Dies ermöglicht die Zuordnung einer Provision.</p>
+        <p>Datenschutzhinweise von eBay:<br><a href="https://www.ebay.de/help/policies/member-behavior-policies/privacy-policy?id=4260">https://www.ebay.de/help/policies/member-behavior-policies/privacy-policy?id=4260</a></p>
+        <h2>7. Weitergabe von Daten</h2>
+        <p>Eine Weitergabe personenbezogener Daten findet nur statt, wenn:</p>
+        <ul>
+          <li>eine Einwilligung vorliegt (Art. 6 Abs. 1 lit. a DSGVO),</li>
+          <li>dies zur Vertragserfüllung erforderlich ist (Art. 6 Abs. 1 lit. b DSGVO),</li>
+          <li>eine rechtliche Verpflichtung besteht (Art. 6 Abs. 1 lit. c DSGVO),</li>
+          <li>dies zur Wahrung berechtigter Interessen erforderlich ist (Art. 6 Abs. 1 lit. f DSGVO).</li>
+        </ul>
+        <h2>8. Rechte der betroffenen Personen</h2>
+        <p>Sie haben nach DSGVO insbesondere folgende Rechte:</p>
+        <ul>
+          <li>Auskunft (Art. 15 DSGVO)</li>
+          <li>Berichtigung (Art. 16 DSGVO)</li>
+          <li>Löschung (Art. 17 DSGVO)</li>
+          <li>Einschränkung der Verarbeitung (Art. 18 DSGVO)</li>
+          <li>Datenübertragbarkeit (Art. 20 DSGVO)</li>
+          <li>Widerspruch gegen die Verarbeitung (Art. 21 DSGVO)</li>
+        </ul>
+        <p>Kontakt: siehe oben unter Verantwortlicher.</p>
+        <h2>9. Beschwerderecht</h2>
+        <p>Sie haben das Recht, sich bei einer Datenschutzaufsichtsbehörde über die Verarbeitung Ihrer personenbezogenen Daten zu beschweren.</p>
+        <h2>10. Aktualität</h2>
+        <p>Diese Datenschutzerklärung ist gültig ab [Monat/Jahr].<br>Wir behalten uns vor, sie bei Änderungen der eingesetzten Technologien oder der rechtlichen Vorgaben anzupassen.</p>
       <h2 id="cookie-einstellungen">Cookie-Einstellungen</h2>
       <p>Du kannst deine Einwilligung jederzeit ändern:</p>
       <div class="cookie-actions">

--- a/public/styles.css
+++ b/public/styles.css
@@ -58,7 +58,7 @@ a:hover{text-decoration:underline}
 .pi-head .pi-title{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .content-section,.price-indicator{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:14px;margin:14px 0}
 
-.legend{display:flex;flex-wrap:wrap;gap:12px;margin:6px 0 10px}
+.legend{display:flex;flex-direction:column;gap:12px;margin:6px 0 10px}
 .legend-item{display:flex;align-items:center;gap:8px;font-size:.95rem}
 .swatch{display:inline-block;width:12px;height:12px;border-radius:3px}
 .swatch.good{background:var(--good)}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -26,19 +26,19 @@
         Preisindikator
         <button type="button" class="info-badge" aria-label="Erklärung zum Preisindikator" aria-expanded="false">
           ⓘ
-          <span class="tip" role="tooltip">
-            <strong>So liest du das:</strong> Wir setzen drei Bereiche. Liegt ein Angebot <em>unter {{ '%.0f'|format(good or 0) }} €</em>,
-            markieren wir es als <strong>Top-Deal</strong>. Bis <em>{{ '%.0f'|format(ok or 0) }} €</em> ist der Preis in Ordnung.
-            Darüber ist es eher teuer. Die Schwellen basieren auf typischen Marktpreisen &amp; Erfahrungswerten.
-            <br><em>Transparenz:</em> Links sind Affiliate-Links. Für dich ändert sich der Preis nicht.
-          </span>
-        </button>
-      </h2>
-    </div>
-    {% if good and ok %}
+            <span class="tip" role="tooltip">
+              <strong>So liest du das:</strong> Wir setzen drei Bereiche. Liegt ein Angebot <em>unter {{ '%.0f'|format(good or 0) }}&nbsp;€</em>,
+              markieren wir es als <strong>Top-Deal</strong>. Bis <em>{{ '%.0f'|format(ok or 0) }}&nbsp;€</em> ist der Preis in Ordnung.
+              Darüber ist es eher teuer. Die Schwellen basieren auf typischen Marktpreisen &amp; Erfahrungswerten.
+              <br><em>Transparenz:</em> Links sind Affiliate-Links. Für dich ändert sich der Preis nicht.
+            </span>
+          </button>
+        </h2>
+      </div>
+      {% if good and ok %}
       <div class="legend">
-        <span class="legend-item"><span class="swatch good"></span> <strong>gut</strong>: unter {{ '%.0f'|format(good) }} €</span>
-        <span class="legend-item"><span class="swatch ok"></span> <strong>ok</strong>: bis {{ '%.0f'|format(ok) }} €</span>
+        <span class="legend-item"><span class="swatch good"></span> <strong>gut</strong>: unter {{ '%.0f'|format(good) }}&nbsp;€</span>
+        <span class="legend-item"><span class="swatch ok"></span> <strong>ok</strong>: bis {{ '%.0f'|format(ok) }}&nbsp;€</span>
         <span class="legend-item"><span class="swatch high"></span> <strong>teuer</strong>: darüber</span>
       </div>
     {% else %}
@@ -98,12 +98,12 @@
           <article class="offer-card{% if is_top %} top{% endif %}" data-offer data-accessory="{{ '1' if o.is_accessory else '0' }}" data-condition="{{ o.condition|lower if o.condition else '' }}">
             {% if is_top %}<div class="badge">Top-Deal</div>{% endif %}
             {% if o.is_accessory %}<div class="badge badge-grey" title="Zubehör/Erweiterung">Zubehör</div>{% endif %}
-            {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
-            <h3 class="offer-title">{{ o.title }}</h3>
-            <div class="offer-meta">
-              <span class="price">{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }} €{% else %}–{% endif %}</span>
-              {% if o.condition %}<span class="condition">{{ o.condition }}</span>{% endif %}
-            </div>
+              {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
+              <h3 class="offer-title"><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a></h3>
+              <div class="offer-meta">
+                <span class="price">{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}</span>
+                {% if o.condition %}<span class="condition">{{ o.condition }}</span>{% endif %}
+              </div>
             <a class="btn btn-secondary offer-link" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">
               {% if 'ebay' in o.url %}Zum Angebot auf eBay{% else %}Zum Angebot{% endif %}
             </a>
@@ -126,8 +126,8 @@
         {% for o in offers %}
           {% set is_top = (good and o.price_eur is number and o.price_eur <= good) %}
           <tr{% if is_top %} class="top"{% endif %} data-offer data-accessory="{{ '1' if o.is_accessory else '0' }}" data-condition="{{ o.condition|lower if o.condition else '' }}">
-            <td>{{ o.title }}</td>
-            <td>{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }} €{% else %}–{% endif %}</td>
+              <td><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a></td>
+              <td>{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}</td>
             <td>{{ o.condition or '–' }}</td>
             <td>{% if o.is_accessory %}Ja{% else %}–{% endif %}</td>
             <td>{% if 'ebay' in o.url %}eBay{% else %}–{% endif %}</td>


### PR DESCRIPTION
## Summary
- prevent euro symbol from wrapping onto new line and link offer titles
- stack price indicator legend vertically
- replace privacy policy with detailed GDPR-compliant text

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b7eff75c8321b81176cd4a1ff353