### PR TITLE
Link price button to eBay search when offers missing

### DIFF
--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -45,7 +45,11 @@
       <p class="muted">Für dieses Spiel haben wir noch keine Preisschwellen hinterlegt.</p>
     {% endif %}
     <div class="cta-row">
+      {% if offers and offers|length > 0 %}
       <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
+      {% else %}
+      <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
+      {% endif %}
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Build script constructs eBay search URL with EPN tracking parameters
- "Jetzt Angebote ansehen" button links to that search when no offers are available

## Testing
- `EPN_CAMPAIGN_ID=123 EPN_REFERENCE_ID=test python scripts/build.py`
- `rg 'Jetzt Angebote ansehen' -n dist/spiel/azul/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a1b546a6848321a150da144a7959c3