### PR TITLE
Fold filters and move results on all games page

### DIFF
--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -12,22 +12,25 @@
   </div>
 </details>
 <div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
-<div class="filters">
-  <label>Spieler <input id="filter-players" type="number" min="1" placeholder="z. B. 4"></label>
-  <label>Alter <input id="filter-age" type="number" min="0" placeholder="z. B. 10"></label>
-  {% if themes %}
-  <label>Thema
-    <select id="filter-theme">
-      <option value="">Alle</option>
-      {% for t in themes %}
-      <option value="{{ t }}">{{ t }}</option>
-      {% endfor %}
-    </select>
-  </label>
-  {% endif %}
-</div>
 <ul class="game-list" data-list>
 {% for g in games %}
   <li data-min-players="{{ g.min_players }}" data-max-players="{{ g.max_players }}" data-age="{{ g.age if g.age is not none else '' }}" data-themes="{{ g.themes|join(',') }}"><a href="/spiel/{{ g.slug }}/">{{ g.title_short }}</a></li>
 {% endfor %}
 </ul>
+<details>
+  <summary>Filter</summary>
+  <div class="filters">
+    <label>Spieler <input id="filter-players" type="number" min="1" placeholder="z. B. 4"></label>
+    <label>Alter <input id="filter-age" type="number" min="0" placeholder="z. B. 10"></label>
+    {% if themes %}
+    <label>Thema
+      <select id="filter-theme">
+        <option value="">Alle</option>
+        {% for t in themes %}
+        <option value="{{ t }}">{{ t }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% endif %}
+  </div>
+</details>


### PR DESCRIPTION
## Summary
- Hide all game filters behind a new “Filter” details toggle
- Display game search results directly below the search field

## Testing
- `python scripts/build.py && echo build-complete`


------
https://chatgpt.com/codex/tasks/task_e_68a1c890b36483219722c47e57e79666