### PR TITLE
Refactor game list filter and move help to FAQ

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -50,14 +50,22 @@
       var pMatch = true;
       var aMatch = true;
       var tMatch = true;
-      if (players){
+      if (players !== null){
         var min = parseInt(li.dataset.minPlayers,10);
         var max = parseInt(li.dataset.maxPlayers,10);
-        if (min && max){ pMatch = players >= min && players <= max; }
+        if (!isNaN(min) && !isNaN(max)){
+          pMatch = players >= min && players <= max;
+        }else{
+          pMatch = false;
+        }
       }
-      if (age){
+      if (age !== null){
         var gAge = parseInt(li.dataset.age,10);
-        if (gAge){ aMatch = gAge <= age; }
+        if (!isNaN(gAge)){
+          aMatch = gAge <= age;
+        }else{
+          aMatch = false;
+        }
       }
       if (theme){
         var themes = li.dataset.themes ? li.dataset.themes.split(',') : [];

--- a/public/styles.css
+++ b/public/styles.css
@@ -82,6 +82,9 @@ a:hover{text-decoration:underline}
 .offer-link{display:inline-flex;align-items:center}
 .search{margin:20px 0}
 .search input{width:100%;padding:14px 16px;border:1px solid var(--border);border-radius:12px;font-size:1.05rem}
+.controls{display:flex;gap:12px;align-items:flex-start;margin:20px 0}
+.controls .search{flex:1;margin:0}
+.controls details{margin:0}
 .filters{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0}
 .filters label{display:flex;flex-direction:column;font-size:.95rem;flex:1 1 120px}
 .filters input,.filters select{padding:8px 10px;border:1px solid var(--border);border-radius:8px}

--- a/templates/games.html.jinja
+++ b/templates/games.html.jinja
@@ -1,36 +1,27 @@
 <h1>Alle Spiele</h1>
 <p>Aktuelle Angebote &amp; Preisindikator für Brettspiele. Nutze Suche oder Filter:</p>
-<details class="help-details">
-  <summary>Wie funktioniert diese Seite?</summary>
-  <div class="help-body">
-    <ol class="steps">
-      <li><strong>Kaufberatung:</strong> Für wen passt das Spiel? Was beachten?</li>
-      <li><strong>Preisindikator:</strong> Einordnung gut/ok/teuer &amp; Top-Deals.</li>
-      <li><strong>Angebote:</strong> Aktualisierte eBay-Listings in EUR. „Zum Angebot“ öffnet eBay.</li>
-      <li><strong>Checkliste &amp; FAQs:</strong> Hilfe für Gebrauchtkauf &amp; häufige Fragen.</li>
-    </ol>
-  </div>
-</details>
-<div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
+<div class="controls">
+  <div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
+  <details>
+    <summary>Filter</summary>
+    <div class="filters">
+      <label>Spieler <input id="filter-players" type="number" min="1" placeholder="z. B. 4"></label>
+      <label>Alter <input id="filter-age" type="number" min="0" placeholder="z. B. 10"></label>
+      {% if themes %}
+      <label>Thema
+        <select id="filter-theme">
+          <option value="">Alle</option>
+          {% for t in themes %}
+          <option value="{{ t }}">{{ t }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      {% endif %}
+    </div>
+  </details>
+</div>
 <ul class="game-list" data-list>
 {% for g in games %}
-  <li data-min-players="{{ g.min_players }}" data-max-players="{{ g.max_players }}" data-age="{{ g.age if g.age is not none else '' }}" data-themes="{{ g.themes|join(',') }}"><a href="/spiel/{{ g.slug }}/">{{ g.title_short }}</a></li>
+  <li{% if g.min_players is not none %} data-min-players="{{ g.min_players }}"{% endif %}{% if g.max_players is not none %} data-max-players="{{ g.max_players }}"{% endif %}{% if g.age is not none %} data-age="{{ g.age }}"{% endif %}{% if g.themes %} data-themes="{{ g.themes|join(',') }}"{% endif %}><a href="/spiel/{{ g.slug }}/">{{ g.title_short }}</a></li>
 {% endfor %}
 </ul>
-<details>
-  <summary>Filter</summary>
-  <div class="filters">
-    <label>Spieler <input id="filter-players" type="number" min="1" placeholder="z. B. 4"></label>
-    <label>Alter <input id="filter-age" type="number" min="0" placeholder="z. B. 10"></label>
-    {% if themes %}
-    <label>Thema
-      <select id="filter-theme">
-        <option value="">Alle</option>
-        {% for t in themes %}
-        <option value="{{ t }}">{{ t }}</option>
-        {% endfor %}
-      </select>
-    </label>
-    {% endif %}
-  </div>
-</details>

--- a/templates/landing.html.jinja
+++ b/templates/landing.html.jinja
@@ -25,6 +25,14 @@
 
 <h2>FAQ – Häufige Fragen zu Brettspielpreisradar</h2>
 
+<h3>Wie funktioniert diese Seite?</h3>
+<ol class="steps">
+  <li><strong>Kaufberatung:</strong> Für wen passt das Spiel? Was beachten?</li>
+  <li><strong>Preisindikator:</strong> Einordnung gut/ok/teuer &amp; Top-Deals.</li>
+  <li><strong>Angebote:</strong> Aktualisierte eBay-Listings in EUR. „Zum Angebot“ öffnet eBay.</li>
+  <li><strong>Checkliste &amp; FAQs:</strong> Hilfe für Gebrauchtkauf &amp; häufige Fragen.</li>
+</ol>
+
 <h3>Was ist Brettspielpreisradar?</h3>
 <p>Brettspielpreisradar ist eine Webseite für Brettspiel-Angebote und Preisvergleiche. Wir sammeln automatisch Preise aus verschiedenen Online-Shops und zeigen dir, wo du Brettspiele aktuell am günstigsten kaufen kannst.</p>
 


### PR DESCRIPTION
## Summary
- remove help section from game list and move steps into landing FAQ
- show filters next to search and tighten filtering logic

## Testing
- `python scripts/build.py`
- `ls -R dist | head`

------
https://chatgpt.com/codex/tasks/task_e_68a1d7c3aa3c8321875f66f6ab087bc9