### PR TITLE
Handle zero price thresholds in indicator

### DIFF
--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -35,7 +35,7 @@
           </button>
         </h2>
       </div>
-      {% if good and ok %}
+      {% if good is not none and ok is not none %}
       <div class="legend">
         <span class="legend-item"><span class="swatch good"></span> <strong>gut</strong>: unter {{ '%.0f'|format(good) }}&nbsp;€</span>
         <span class="legend-item"><span class="swatch ok"></span> <strong>ok</strong>: bis {{ '%.0f'|format(ok) }}&nbsp;€</span>


### PR DESCRIPTION
## Summary
- treat explicit `0` price thresholds as valid in price indicator template

## Testing
- `python scripts/fetch_offers_stub.py`
- `python scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1dabfc65c8321947c95f0dbdcf558