### PR TITLE
Include slug in eBay query generation

### DIFF
--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -143,7 +143,7 @@ def queries_for(game: Dict[str, Any]) -> List[str]:
         q.extend([s for s in terms if isinstance(s, str) and s.strip()])
     if title:
         q += [f"{title} Brettspiel", f"{title} Spiel"]
-    if slug and slug.lower() not in title.lower():
+    if slug:
         q.append(f"{slug.replace('-', ' ')} Brettspiel")
     seen, out = set(), []
     for s in q:


### PR DESCRIPTION
## Summary
- Always include the game's slug when generating eBay search queries to avoid missing results when the title contains extra text

## Testing
- `python -m py_compile scripts/fetch_offers_ebay_enhanced.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1db942bd08321a61b8f5795e985e3