### PR TITLE
Fix desktop navigation and cookie banner visibility

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -120,12 +120,14 @@
 
   function consentAccept(){
     localStorage.setItem('cookie-consent','accepted');
+    document.documentElement.classList.remove('cookies-pending');
     document.documentElement.classList.add('cookies-accepted');
     if (banner) banner.style.display='none';
     if (typeof loadAnalytics === 'function'){ loadAnalytics(); }
   }
   function consentDecline(){
     localStorage.setItem('cookie-consent','declined');
+    document.documentElement.classList.remove('cookies-pending');
     document.documentElement.classList.add('cookies-declined');
     if (banner) banner.style.display='none';
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -50,7 +50,7 @@ a:hover{text-decoration:underline}
 .main-nav.open a:first-child{border-top:none}
 @media (min-width:720px){
   .nav-toggle{display:none}
-  .main-nav{max-height:none;opacity:1;position:static;box-shadow:none;background:transparent;overflow:visible}
+  .main-nav{max-height:none;opacity:1;position:static;box-shadow:none;background:transparent;overflow:visible;pointer-events:auto}
   .main-nav a{display:inline-block;border:none;margin-left:16px;padding:10px 0;color:inherit}
 }
 
@@ -146,7 +146,7 @@ a:hover{text-decoration:underline}
 .footer-inner{padding:20px 16px}
 .muted{color:var(--muted)}
 
-.cookie-banner{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:#fff;color:var(--text);border-top:1px solid var(--border);box-shadow:var(--shadow);padding:16px 20px;display:flex;flex-direction:column;align-items:center;gap:16px;font-size:.9rem;text-align:center;border-radius:12px 12px 0 0}
+.cookie-banner{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:#fff;color:var(--text);border-top:1px solid var(--border);box-shadow:var(--shadow);padding:16px 20px;display:none;flex-direction:column;align-items:center;gap:16px;font-size:.9rem;text-align:center;border-radius:12px 12px 0 0}
 .cookie-banner .cookie-actions{display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center}
 .cookie-banner button{border:none;border-radius:8px;padding:6px 12px;cursor:pointer;font-weight:600;transition:background .3s,transform .3s}
 #cookie-accept,#settings-accept{background:var(--color-primary);color:#fff;padding:10px 20px;font-size:1rem;box-shadow:0 2px 4px rgba(0,0,0,.2)}
@@ -154,8 +154,10 @@ a:hover{text-decoration:underline}
 #cookie-decline,#settings-decline,#cookie-settings{background:#e2e8f0;color:var(--text)}
 .cookie-banner .cookie-more,.cookie-banner .cookie-settings-link{color:var(--color-primary);font-size:.85rem}
 .cookies-accepted .cookie-banner,.cookies-declined .cookie-banner{display:none}
-.cookie-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);z-index:999}
+.cookie-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);z-index:999}
 .cookies-accepted .cookie-overlay,.cookies-declined .cookie-overlay{display:none}
+.cookies-pending .cookie-banner{display:flex}
+.cookies-pending .cookie-overlay{display:block}
 
 .consent-status{margin-top:10px;font-size:.9rem;color:var(--color-primary);display:none;text-align:center}
 

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -33,6 +33,8 @@
       loadAnalytics();
     }else if(consent==='declined'){
       document.documentElement.classList.add('cookies-declined');
+    }else{
+      document.documentElement.classList.add('cookies-pending');
     }
   </script>
 </head>


### PR DESCRIPTION
## Summary
- ensure cookie banner and overlay only show when consent pending
- allow desktop navigation to receive pointer events

## Testing
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68a824ff12ac8321a81f110f158cdfd6