### PR TITLE
Add Amazon affiliate link button on game pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ py -m http.server -d dist 8000
 ```
 
 **Mit eBay**
-1) `.env` anlegen mit `EBAY_CLIENT_ID`, `EBAY_CLIENT_SECRET`, `EPN_CAMPAIGN_ID` (und optional `EPN_REFERENCE_ID`).  
+1) `.env` anlegen mit `EBAY_CLIENT_ID`, `EBAY_CLIENT_SECRET`, `EPN_CAMPAIGN_ID` (und optional `EPN_REFERENCE_ID`).
 2) Dann:
 ```bat
 py scripts\fetch_offers_ebay_enhanced.py
 py scripts\build.py
 ```
+
+**Amazon Affiliate**
+
+Setze optional die Umgebungsvariable `AMAZON_PARTNER_ID` (Standard `28310edf-21`), um einen "Preis bei Amazon prüfen"-Button mit Affiliate-Link auf jeder Spieleseite auszugeben.
 
 **YAML Felder (neu & optional)**
 - `how_to_play_60s` (Text), `used_checklist` (Liste), `editions` (note/recommended/avoid), `expansions` (Liste mit name/verdict), `pros`/`cons` (Listen).

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -13,6 +13,7 @@ DIST = ROOT / "dist"
 
 EPN_CAMPAIGN_ID = os.getenv("EPN_CAMPAIGN_ID", "").strip()
 EPN_REFERENCE_ID = os.getenv("EPN_REFERENCE_ID", "preisradar").strip()
+AMAZON_PARTNER_ID = os.getenv("AMAZON_PARTNER_ID", "28310edf-21").strip()
 
 env = Environment(
     loader=FileSystemLoader(str(TEMPLATES)),
@@ -41,6 +42,14 @@ def load_offers(slug):
         return []
     with open(p, "r", encoding="utf-8") as f:
         return json.load(f)
+
+def build_amazon_search_url(game):
+    queries = game.get("search_queries") or game.get("search_terms") or []
+    if isinstance(queries, list) and queries:
+        q = queries[0]
+    else:
+        q = game.get("slug") or ""
+    return f"https://www.amazon.de/s?k={quote_plus(q)}&tag={AMAZON_PARTNER_ID}"
 
 def price_rating(offers, rules):
     prices = [o["price_eur"] for o in offers if "price_eur" in o]
@@ -140,6 +149,7 @@ def render_game(yaml_path, site_url):
     min_price = min(prices) if prices else None
 
     search_url = build_epn_search_url(game)
+    amazon_url = build_amazon_search_url(game)
     page_tpl = env.get_template("page.html.jinja")
     page_html = page_tpl.render(
         game=game,
@@ -149,7 +159,8 @@ def render_game(yaml_path, site_url):
         avg30=avg30, avg60=avg60, avg90=avg90,
         delta60=delta60,
         min_price=min_price,
-        ebay_search_url=search_url
+        ebay_search_url=search_url,
+        amazon_search_url=amazon_url
     )
 
     layout_tpl = env.get_template("layout.html.jinja")

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -113,6 +113,15 @@
             </a>
           </article>
         {% endfor %}
+        {% if amazon_search_url %}
+          <article class="offer-card" data-offer>
+            <h3 class="offer-title"><a href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Amazon</a></h3>
+            <div class="offer-meta">
+              <span class="price">–</span>
+            </div>
+            <a class="btn btn-secondary offer-link" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis bei Amazon prüfen</a>
+          </article>
+        {% endif %}
       </div>
 
       <table class="offer-table">
@@ -138,10 +147,25 @@
             <td><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a></td>
           </tr>
         {% endfor %}
+        {% if amazon_search_url %}
+          <tr>
+            <td><a href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Amazon</a></td>
+            <td>–</td>
+            <td>–</td>
+            <td>–</td>
+            <td>Amazon</td>
+            <td><a href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis bei Amazon prüfen</a></td>
+          </tr>
+        {% endif %}
         </tbody>
       </table>
     {% else %}
       <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
+      {% if amazon_search_url %}
+      <div class="cta-row">
+        <a class="btn btn-secondary" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis bei Amazon prüfen</a>
+      </div>
+      {% endif %}
     {% endif %}
   </section>
 


### PR DESCRIPTION
## Summary
- add environment-configurable Amazon partner ID
- generate Amazon search link for each game and show 'Preis bei Amazon prüfen' button
- document Amazon partner ID usage in README

## Testing
- `python scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68a882fd49788321be1177bbe71946a6