### PR TITLE
Track daily price history for offers

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -48,6 +50,16 @@ jobs:
         env:
           SITE_URL: https://brettspielpreisradar.de/
         run: python scripts/build.py
+
+      - name: Commit price history
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add data/history || true
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update price history"
+            git push origin main
+          fi
 
       # absolute /pfade -> SITE_URL umschreiben
       - name: Rewrite absolute asset links to SITE_URL

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ __pycache__/
 *.pyc
 .env
 data/offers/*.json
-data/history/*.jsonl


### PR DESCRIPTION
## Summary
- capture today's average offer price per game and append to `data/history/<slug>.jsonl`
- ensure GitHub Actions commits updated history files back to `main`
- allow history files to be tracked in git

## Testing
- `python scripts/fetch_offers_stub.py`
- `python scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b33d0d4883219ce26dde38e619cd