### PR TITLE
Refine price indicator and offers layout

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -73,7 +73,7 @@ a:hover{text-decoration:underline}
 .content-section{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:14px;margin:14px 0}
 
 /* Price Indicator */
-.price-indicator{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:14px 0;max-width:560px;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:var(--pi-fg)}
+.price-indicator{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:var(--pi-fg)}
 .pi-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
 .pi-title{font-weight:600}
 .pi-badge{font-weight:700;padding:4px 8px;border-radius:999px;background:var(--pi-bg)}
@@ -81,12 +81,8 @@ a:hover{text-decoration:underline}
 .pi-badge.orange{background:color-mix(in srgb,var(--pi-orange) 14%,white);color:var(--pi-orange)}
 .pi-badge.red{background:color-mix(in srgb,var(--pi-red) 14%,white);color:var(--pi-red)}
 
-.pi-bar{position:relative;height:10px;border-radius:999px;overflow:hidden;display:grid;grid-template-columns:1fr 1fr 1fr;margin:8px 0 6px;box-shadow:inset 0 0 0 1px var(--pi-ring)}
-.pi-segment{height:100%}
-.pi-green{background:color-mix(in srgb,var(--pi-green) 18%,white)}
-.pi-orange{background:color-mix(in srgb,var(--pi-orange) 18%,white)}
-.pi-red{background:color-mix(in srgb,var(--pi-red) 18%,white)}
-.pi-marker{position:absolute;top:-4px;width:0;height:18px;border-left:2px solid #111;left:50%}
+.pi-bar{position:relative;height:10px;border-radius:999px;overflow:hidden;margin:8px 0 6px;box-shadow:inset 0 0 0 1px var(--pi-ring);background:linear-gradient(to right,color-mix(in srgb,var(--pi-green) 18%,white) 0%,color-mix(in srgb,var(--pi-green) 18%,white) 33.33%,color-mix(in srgb,var(--pi-orange) 18%,white) 33.33%,color-mix(in srgb,var(--pi-orange) 18%,white) 66.66%,color-mix(in srgb,var(--pi-red) 18%,white) 66.66%,color-mix(in srgb,var(--pi-red) 18%,white) 100%)}
+.pi-marker{position:absolute;top:-4px;width:2px;height:18px;background:#111;left:50%;transform:translateX(-1px)}
 
 .pi-sparkline{width:100%;height:36px;margin:2px 0 8px}
 .pi-sparkline path{fill:none;stroke:currentColor;stroke-width:1.4}
@@ -98,8 +94,16 @@ a:hover{text-decoration:underline}
 .pi-note{margin:6px 0 0;color:var(--pi-muted);font-size:12px}
 @media (max-width:420px){ .pi-stats{grid-template-columns:1fr} }
 
+.price-top{display:flex;flex-direction:column;gap:14px;margin:14px 0}
+@media (min-width:880px){.price-top{flex-direction:row}
+  .price-top .price-indicator,.price-top .price-history{flex:1}
+}
+.price-history{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff}
+.info-icon{display:inline-block;width:14px;height:14px;border-radius:50%;background:var(--info);color:var(--text);font-size:.7rem;line-height:14px;text-align:center;margin-left:4px;cursor:help}
+
 .cta-row{margin-top:8px}
 .btn{display:inline-flex;align-items:center;justify-content:center;border-radius:12px;border:1px solid transparent;padding:12px 14px;font-weight:700;min-height:44px}
+.btn-sm{min-height:36px;padding:8px 10px;font-size:.9rem}
 .btn-primary{background:var(--color-primary);color:white;width:100%}
 .btn-primary:hover{opacity:.92;text-decoration:none}
 .btn-secondary{background:var(--color-secondary);color:white;width:100%}
@@ -151,6 +155,7 @@ a:hover{text-decoration:underline}
 }
 .offer-meta{display:flex;align-items:center;justify-content:space-between;margin:4px 0 10px}
 .price{font-size:1.2rem;font-weight:800}
+.price .shipping{font-size:.8rem;font-weight:400;color:var(--muted)}
 .condition{font-size:.9rem;color:#0f172a;background:#f1f5f9;border:1px solid var(--border);border-radius:6px;padding:2px 8px}
 .seller{font-size:.9rem;color:#0f172a;background:#f1f5f9;border:1px solid var(--border);border-radius:6px;padding:2px 8px}
 .offer-card .btn{margin-top:auto}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -20,44 +20,52 @@
   {% if missing_fields %}
   <p class="muted">⚠️ Fehlende YAML-Werte: {{ missing_fields|join(', ') }}</p>
   {% endif %}
+  <div class="price-top">
+    <section class="price-indicator" role="group" aria-label="Preisindikator">
+      <div class="pi-header">
+        <span class="pi-title">Preisindikator</span>
+        <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
+      </div>
 
-  <section class="price-indicator" role="group" aria-label="Preisindikator">
-    <div class="pi-header">
-      <span class="pi-title">Preisindikator</span>
-      <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
-    </div>
+      <div class="pi-bar" aria-hidden="true">
+        <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
+      </div>
 
-    <div class="pi-bar" aria-hidden="true">
-      <div class="pi-segment pi-green"></div>
-      <div class="pi-segment pi-orange"></div>
-      <div class="pi-segment pi-red"></div>
-      <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
-    </div>
+      <svg class="pi-sparkline" viewBox="0 0 100 24" preserveAspectRatio="none" aria-label="Preisverlauf letzte {{ avg_days }} Tage">
+        <path id="pi-line" d=""></path>
+        <circle id="pi-dot" r="1.6" cx="99" cy="0"></circle>
+      </svg>
 
-    <svg class="pi-sparkline" viewBox="0 0 100 24" preserveAspectRatio="none" aria-label="Preisverlauf letzte {{ avg_days }} Tage">
-      <path id="pi-line" d=""></path>
-      <circle id="pi-dot" r="1.6" cx="100" cy="0"></circle>
-    </svg>
+      <dl class="pi-stats">
+        <div><dt>Aktuell<span class="info-icon" title="Niedrigster Gesamtpreis heute inkl. Versand">i</span></dt><dd id="pi-current">–</dd></div>
+        <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">i</span></dt><dd id="pi-avg">–</dd></div>
+        <div><dt>Tief/Hoch<span class="info-icon" title="Niedrigster und höchster Tagespreis in den letzten {{ avg_days }} Tagen">i</span></dt><dd id="pi-range">–</dd></div>
+        <div><dt>Abweichung<span class="info-icon" title="Aktuelle Differenz zum 30-Tage-Durchschnitt">i</span></dt><dd id="pi-diff">–</dd></div>
+      </dl>
 
-    <dl class="pi-stats">
-      <div><dt>Aktuell</dt><dd id="pi-current">–</dd></div>
-      <div><dt>Ø {{ avg_days }} Tage</dt><dd id="pi-avg">–</dd></div>
-      <div><dt>Tief/Hoch</dt><dd id="pi-range">–</dd></div>
-      <div><dt>Abweichung</dt><dd id="pi-diff">–</dd></div>
-    </dl>
+      <p class="pi-note">
+        Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5 % = grün, ±5 % = orange, ≥+5 % = rot.
+      </p>
 
-    <p class="pi-note">
-      Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5 % = grün, ±5 % = orange, ≥+5 % = rot.
-    </p>
+      <div class="cta-row">
+        {% if offers and offers|length > 0 %}
+        <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
+        {% else %}
+        <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
+        {% endif %}
+      </div>
+    </section>
 
-    <div class="cta-row">
-      {% if offers and offers|length > 0 %}
-      <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
+    <section class="price-history">
+      <h2 class="h2">Preisverlauf (30 Tage)<span class="info-icon" title="Tägliche Durchschnittspreise der letzten 30 Tage">i</span></h2>
+      {% if avg30 %}
+        <p class="avg-price">Durchschnitt: {{ '%.2f'|format(avg30) }}&nbsp;€</p>
       {% else %}
-      <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
+        <p class="muted">Noch keine Preisdaten.</p>
       {% endif %}
-    </div>
-  </section>
+      <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
+    </section>
+  </div>
 
   <section class="content-section">
     <h2 class="h2">Kaufberatung</h2>
@@ -90,16 +98,6 @@
   </section>
   {% endif %}
 
-  <section class="content-section price-history">
-    <h2 class="h2">Preisverlauf (30 Tage)</h2>
-    {% if avg30 %}
-      <p class="avg-price">Durchschnitt: {{ '%.2f'|format(avg30) }}&nbsp;€</p>
-    {% else %}
-      <p class="muted">Noch keine Preisdaten.</p>
-    {% endif %}
-    <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
-  </section>
-
   <section class="offers" id="angebote">
     <div class="offers-head">
       <h2 class="h2">Angebote</h2>
@@ -115,7 +113,7 @@
             {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
             <h3 class="offer-title"><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a></h3>
             <div class="offer-meta">
-              <span class="price">{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}</span>
+              <span class="price">{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}{% if o.shipping_eur is number %}<span class="shipping"> + {{ '%.2f'|format(o.shipping_eur) }}&nbsp;€ Versand</span>{% endif %}</span>
               {% if o.shop %}<span class="seller">{{ o.shop }}</span>{% endif %}
             </div>
             <a class="btn btn-secondary offer-link" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot auf eBay</a>
@@ -125,26 +123,28 @@
           <article class="offer-card" data-offer>
             <h3 class="offer-title"><a href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Amazon</a></h3>
             <div class="offer-meta"><span class="price">–</span></div>
-            <a class="btn btn-secondary offer-link" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis bei Amazon prüfen</a>
+            <a class="btn btn-secondary offer-link" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a>
           </article>
         {% endif %}
       </div>
 
       <table class="offer-table">
-        <thead><tr><th>Händler</th><th>Preis</th><th></th></tr></thead>
+        <thead><tr><th>Verkäufer</th><th>Preis</th><th>Versand</th><th></th></tr></thead>
         <tbody>
           {% for o in offers %}
           <tr class="{% if loop.first %}top{% endif %}">
             <td>{{ o.shop }}</td>
-            <td>{% if o.total_eur is number %}{{ '%.2f'|format(o.total_eur) }}&nbsp;€{% else %}–{% endif %}{% if loop.first %}<span class="badge-cheap">Bestpreis</span>{% endif %}</td>
-            <td><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a></td>
+            <td>{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}{% if loop.first %}<span class="badge-cheap">Bestpreis</span>{% endif %}</td>
+            <td>{% if o.shipping_eur is number %}{{ '%.2f'|format(o.shipping_eur) }}&nbsp;€{% else %}–{% endif %}</td>
+            <td><a class="btn btn-secondary btn-sm" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a></td>
           </tr>
           {% endfor %}
           {% if amazon_search_url %}
           <tr>
             <td>Amazon</td>
             <td>–</td>
-            <td><a href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis bei Amazon prüfen</a></td>
+            <td>–</td>
+            <td><a class="btn btn-secondary btn-sm" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a></td>
           </tr>
           {% endif %}
         </tbody>
@@ -153,7 +153,7 @@
       <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
       {% if amazon_search_url %}
       <div class="cta-row">
-        <a class="btn btn-secondary" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis bei Amazon prüfen</a>
+        <a class="btn btn-secondary" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a>
       </div>
       {% endif %}
     {% endif %}


### PR DESCRIPTION
## Summary
- Modernize price indicator with gradient bar, info tooltips, and side-by-side 30-day chart
- Revamp offers table with seller, price, shipping columns plus Amazon check row
- Add shipping info to offer cards and compact buttons for cleaner look

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8c233275c8321a22b1571b94efa2d