### PR TITLE
Fix price indicator average and color marker

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1,4 +1,4 @@
-// ui-version:2025-08-11-v9 – Menü-Overlay, Preisindikator, Suche & Cookie-Banner unten
+// ui-version:2025-08-23-v10 – Menü-Overlay, Preisindikator, Suche & Cookie-Banner unten
 (function(){
   // Menü
   var btn = document.getElementById('nav-toggle');
@@ -24,10 +24,14 @@
     var diffPct = ((d.current - d.avg7) / d.avg7) * 100;
     var badge = document.getElementById('pi-badge');
     if(!badge) return;
+    var marker = document.getElementById('pi-marker');
     var badgeText = (diffPct>0?'+':'') + diffPct.toFixed(1) + '%';
+    var colorClass = diffPct <= -5 ? 'green' : Math.abs(diffPct) <= 5 ? 'orange' : 'red';
     badge.textContent = badgeText;
     badge.classList.remove('green','orange','red');
-    badge.classList.add(diffPct <= -5 ? 'green' : Math.abs(diffPct) <= 5 ? 'orange' : 'red');
+    marker.classList.remove('green','orange','red');
+    badge.classList.add(colorClass);
+    marker.classList.add(colorClass);
     badge.setAttribute('aria-label','Differenz zum Durchschnitt: ' + badgeText);
 
     document.getElementById('pi-current').textContent = d.current.toFixed(2) + ' €';
@@ -35,7 +39,7 @@
 
     var clamp = function(v,min,max){ return Math.min(Math.max(v,min),max); };
     var pos = clamp((diffPct + 15) / 30, 0, 1);
-    document.getElementById('pi-marker').style.left = 'calc(' + (pos*100) + '% - 1px)';
+    marker.style.left = 'calc(' + (pos*100) + '% - 1px)';
 
     var min = Math.min.apply(null, d.history);
     var max = Math.max.apply(null, d.history);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-/* ui-version:2025-08-11-v9 – Neuer Preisindikator */
+/* ui-version:2025-08-23-v10 – Neuer Preisindikator */
 :root{
   --color-primary:#ff7f11;
   --color-secondary:#ff9f1c;
@@ -83,6 +83,9 @@ a:hover{text-decoration:underline}
 
 .pi-bar{position:relative;height:10px;border-radius:999px;overflow:hidden;margin:8px 0 6px;box-shadow:inset 0 0 0 1px var(--pi-ring);background:linear-gradient(to right,color-mix(in srgb,var(--pi-green) 18%,white) 0%,color-mix(in srgb,var(--pi-green) 18%,white) 33.33%,color-mix(in srgb,var(--pi-orange) 18%,white) 33.33%,color-mix(in srgb,var(--pi-orange) 18%,white) 66.66%,color-mix(in srgb,var(--pi-red) 18%,white) 66.66%,color-mix(in srgb,var(--pi-red) 18%,white) 100%)}
 .pi-marker{position:absolute;top:-4px;width:2px;height:18px;background:#111;left:50%;transform:translateX(-1px)}
+.pi-marker.green{background:var(--pi-green)}
+.pi-marker.orange{background:var(--pi-orange)}
+.pi-marker.red{background:var(--pi-red)}
 
 .pi-sparkline{width:100%;height:36px;margin:2px 0 8px}
 .pi-sparkline path{fill:none;stroke:currentColor;stroke-width:1.4}

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -90,7 +90,8 @@ def load_history(slug):
     return rows
 
 def avg_window(rows, days):
-    cutoff = dt.date.today() - dt.timedelta(days=days)
+    """Return average over the last ``days`` days (inclusive)."""
+    cutoff = dt.date.today() - dt.timedelta(days=days - 1)
     vals = [r["avg"] for r in rows if r.get("avg") and r["date"] >= cutoff]
     if not vals:
         return (None, 0)
@@ -132,6 +133,13 @@ def render_game(yaml_path, site_url):
         key=lambda o: o.get("total_eur") or o.get("price_eur") or 1e9,
     )
     append_history(game["slug"], offers)
+
+    # minimaler Preis für Anzeige
+    min_price = None
+    if offers:
+        first = offers[0]
+        min_price = first.get("total_eur") or first.get("price_eur")
+
     # parse player count for template chip
     min_p, max_p = parse_players(game.get("players"))
     if min_p and max_p:
@@ -152,11 +160,13 @@ def render_game(yaml_path, site_url):
     ]
     hist_days = len(hist30)
 
-    # minimaler Preis für Anzeige
-    min_price = None
-    if offers:
-        first = offers[0]
-        min_price = first.get("total_eur") or first.get("price_eur")
+    if min_price is not None:
+        today = dt.date.today().isoformat()
+        if hist30 and hist30[-1]["date"] == today:
+            hist30[-1]["avg"] = round(min_price, 2)
+        else:
+            hist30.append({"date": today, "avg": round(min_price, 2)})
+        hist_days = len(hist30)
 
     price_trend = None
     if min_price is not None and avg7:

--- a/templates/landing.html.jinja
+++ b/templates/landing.html.jinja
@@ -35,6 +35,10 @@
     </ol>
   </details>
   <details>
+    <summary>Wie berechnet ihr den Preisindikator?</summary>
+    <p>Wir erfassen täglich den günstigsten Gesamtpreis (Preis&nbsp;+&nbsp;Versand) jedes Spiels. Aus diesen Tageswerten bilden wir einen Durchschnitt der letzten 7&nbsp;Tage und vergleichen ihn mit dem aktuellen Preis. 5&nbsp;% günstiger oder mehr = grün, etwa gleich = orange, 5&nbsp;% teurer oder mehr = rot.</p>
+  </details>
+  <details>
     <summary>Was ist Brettspielpreisradar?</summary>
     <p>Brettspielpreisradar ist eine Webseite für Brettspiel-Angebote und Preisvergleiche. Wir sammeln automatisch Preise aus verschiedenen Online-Shops und zeigen dir, wo du Brettspiele aktuell am günstigsten kaufen kannst.</p>
   </details>

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -42,7 +42,7 @@
       </dl>
 
       <p class="pi-note">
-        Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5 % = grün, ±5 % = orange, ≥+5 % = rot.
+        Basis ist der tägliche Gesamtpreis (Preis&nbsp;+&nbsp;Versand). Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5&nbsp;% = grün, ±5&nbsp;% = orange, ≥+5&nbsp;% = rot.
       </p>
 
       <div class="cta-row">


### PR DESCRIPTION
## Summary
- fix off-by-one bug in 7-day average calculation and ensure chart shows today's price
- color price indicator marker to match badge state
- document price calculation in FAQ and note total price basis

## Testing
- `python3 scripts/build.py`


------
https://chatgpt.com/codex/tasks/task_e_68a98d8ad3b48321ace87d6a0b800000