### PR TITLE
Track minimum price per day

### DIFF
--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -159,7 +159,7 @@
     if(hist.length){
       const ctx = document.getElementById('priceHistoryChart');
       const labels = hist.map(r=>r.date);
-      const data = hist.map(r=>r.avg);
+      const data = hist.map(r=>r.min);
       new Chart(ctx,{type:'line',data:{labels:labels,datasets:[{label:'Preis',data:data,borderColor:'#3e95cd',fill:false}]},options:{plugins:{legend:{display:false}},scales:{y:{ticks:{callback:(v)=>v+' €'}}}}});
       {% if min_price and avg7 %}
       if (typeof window.renderPI === 'function'){


### PR DESCRIPTION
## Summary
- record daily minimum price using `min` field and replace existing entry for the day
- read `min` values when loading history and compute per-day minimums
- update history chart to consume new `min` data

## Testing
- `python -m py_compile scripts/build.py`
- `python scripts/build.py && ls dist | head`


------
https://chatgpt.com/codex/tasks/task_e_68a9960b8cd88321b0e8c787573c5fb6