### PR TITLE
Use high resolution eBay images

### DIFF
--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -17,7 +17,7 @@ import os, json, time, datetime as dt
 from pathlib import Path
 from typing import List, Dict, Any
 from urllib.parse import quote_plus
-import requests, yaml
+import requests, yaml, re
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTENT_DIR = ROOT / "content" / "games"
@@ -179,6 +179,14 @@ def build_url(item, slug: str) -> str:
         url += f"{sep}campid={EPN_CAMPAIGN_ID}&customid={EPN_REFERENCE_ID}-{slug}"
     return url
 
+def high_res_image(url: str | None) -> str | None:
+    """Return a higher resolution variant of an eBay image URL if possible."""
+    if not url:
+        return url
+    # eBay image URLs encode the size as `s-l###`. Replace with the largest
+    # commonly available size to avoid pixelated thumbnails.
+    return re.sub(r"s-l\d+", "s-l1600", url)
+
 def queries_for(game: Dict[str, Any]) -> List[str]:
     title = (game.get("title") or "").strip()
     slug = (game.get("slug") or "").strip()
@@ -246,7 +254,7 @@ def fetch_for_game(game: Dict[str, Any], max_keep: int = 10) -> List[Dict[str, A
             if acc_type != SELLER_ACCOUNT_TYPE:
                 continue
             shop = seller.get("username") or "eBay"
-            img = (it.get("image") or {}).get("imageUrl")
+            img = high_res_image((it.get("image") or {}).get("imageUrl"))
             offer = {
                 "id": iid,
                 "title": title[:140],

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -74,3 +74,9 @@ def test_fetch_for_game_passes_min_price():
         mod.fetch_for_game(game)
         _, kwargs = mock_search.call_args
         assert kwargs["min_price"] == 5
+
+
+def test_high_res_image_upgrades_thumbnail_url():
+    mod = load_module()
+    url = "https://i.ebayimg.com/images/g/abc/s-l225.jpg"
+    assert mod.high_res_image(url).endswith("s-l1600.jpg")


### PR DESCRIPTION
## Summary
- Upgrade eBay image URLs to their highest resolution variant
- Cover high-res transformation with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad06496648321b91bc51c84fb36a5