### PR TITLE
feat: support aspect filters for eBay search

### DIFF
--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -39,13 +39,19 @@ def test_search_once_adds_filters():
         mock_resp.status_code = 200
         mock_resp.json.return_value = {}
         mock_get.return_value = mock_resp
-        mod.search_once("catan", category_id="180349", min_price=20)
+        mod.search_once(
+            "catan",
+            category_id="180349",
+            min_price=20,
+            aspect_filters={"Produktart": ["Eigenständiges Spiel"]},
+        )
         _, kwargs = mock_get.call_args
         assert "filter" in kwargs["params"]
         flt = kwargs["params"]["filter"]
         assert "categoryIds:180349" in flt
         assert "price:[20..]" in flt
         assert "buyingOptions:{FIXED_PRICE}" in flt
+        assert kwargs["params"].get("aspect_filter") == "Produktart:Eigenständiges Spiel"
 
 
 def test_fetch_for_game_fallback_to_other_sellers():
@@ -74,3 +80,17 @@ def test_fetch_for_game_passes_min_price():
         mod.fetch_for_game(game)
         _, kwargs = mock_search.call_args
         assert kwargs["min_price"] == 5
+
+
+def test_fetch_for_game_passes_aspect_filters():
+    mod = load_module()
+    game = {
+        "slug": "catan",
+        "search_terms": ["Catan"],
+        "aspect_filters": {"Produktart": ["Eigenständiges Spiel"]},
+    }
+    with patch("scripts.fetch_offers_ebay_enhanced.search_once") as mock_search:
+        mock_search.return_value = []
+        mod.fetch_for_game(game)
+        _, kwargs = mock_search.call_args
+        assert kwargs["aspect_filters"] == {"Produktart": ["Eigenständiges Spiel"]}


### PR DESCRIPTION
## Summary
- allow passing aspect filters from game YAML to eBay API requests
- cover aspect filter handling with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacff4de308321b6c097ee975efae7