### PR TITLE
Respect per-game exclude keywords for eBay offers

### DIFF
--- a/config/filters.yaml
+++ b/config/filters.yaml
@@ -46,3 +46,7 @@ condition_ids:
 # Require offers to come from this seller account type to filter out private
 # listings.
 seller_account_type: BUSINESS
+
+# Limit offers to items located in these countries (ISO codes)
+item_location_countries:
+  - DE


### PR DESCRIPTION
## Summary
- allow optional game-specific keywords when filtering eBay results
- add regression test verifying `exclude_keywords` are honored
- support filtering by item location via `item_location_countries` config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab056d56a88321bca673968dc41f2c