### PR TITLE
Revamp offer grid with total price and affiliate note

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -131,15 +131,7 @@ a:hover{text-decoration:underline}
 
 /* NEWER offer layout (Grid/Card) with responsive table fallback */
 .offer-grid{display:grid;grid-template-columns:1fr;gap:12px}
-@media (min-width:480px){ .offer-grid{grid-template-columns:repeat(2,minmax(0,1fr))} }
-@media (min-width:880px){ .offer-grid{grid-template-columns:repeat(3,minmax(0,1fr))} }
-.offer-table{display:none;width:100%;border-collapse:collapse;margin-top:12px}
-.offer-table th,.offer-table td{border:1px solid var(--border);padding:8px;text-align:left}
-.offer-table tr.top{background:rgba(22,163,74,.08)}
-@media (min-width:880px){
-  .offer-grid{display:none}
-  .offer-table{display:table}
-}
+@media (min-width:640px){ .offer-grid{grid-template-columns:repeat(2,minmax(0,1fr))} }
 .offer-card{
   position:relative;background:var(--card);border:1px solid var(--border);border-radius:14px;padding:14px;box-shadow:0 2px 8px rgba(0,0,0,.04);
   display:flex;flex-direction:column;min-height:320px;
@@ -153,11 +145,10 @@ a:hover{text-decoration:underline}
   margin:0 0 8px;font-size:1rem;
   display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;min-height:2.6em;line-height:1.3;
 }
-.offer-meta{display:flex;align-items:center;justify-content:space-between;margin:4px 0 10px}
-.price{font-size:1.2rem;font-weight:800}
-.price .shipping{font-size:.8rem;font-weight:400;color:var(--muted)}
+.offer-meta{display:flex;flex-direction:column;align-items:flex-start;margin:4px 0 10px}
+.price{font-size:1.3rem;font-weight:800}
 .condition{font-size:.9rem;color:#0f172a;background:#f1f5f9;border:1px solid var(--border);border-radius:6px;padding:2px 8px}
-.seller{font-size:.9rem;color:#0f172a;background:#f1f5f9;border:1px solid var(--border);border-radius:6px;padding:2px 8px}
+.seller{font-size:.8rem;color:var(--muted)}
 .offer-card .btn{margin-top:auto}
 .price-chart{margin-top:20px}
 .price-history .avg-price{font-weight:700;font-size:1.1rem;margin:0}
@@ -173,6 +164,7 @@ a:hover{text-decoration:underline}
 .footer-nav a:last-child{margin-right:0}
 .footer-inner{padding:20px 16px}
 .muted{color:var(--muted)}
+.affiliate-note{font-size:.8rem;margin:8px 0}
 
 .cookie-banner{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:#fff;color:var(--text);border-top:1px solid var(--border);box-shadow:var(--shadow);padding:16px 20px;display:none;flex-direction:column;align-items:center;gap:16px;font-size:.9rem;text-align:center;border-radius:12px 12px 0 0}
 .cookie-banner .cookie-actions{display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -97,6 +97,8 @@
       <small class="muted">Sortierung nach Gesamtpreis (aufsteigend), nur Angebote in EUR.</small>
     </div>
 
+    <p class="affiliate-note muted">Transparenz: Links mit „Zum Angebot“ sind Affiliate-Links. Kaufst du darüber, erhalten wir ggf. eine Provision – für dich bleibt der Preis gleich.</p>
+
     {% if offers and offers|length > 0 %}
       <div class="offer-grid">
         {% for o in offers %}
@@ -106,10 +108,10 @@
             {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
             <h3 class="offer-title"><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a></h3>
             <div class="offer-meta">
-              <span class="price">{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}{% if o.shipping_eur is number %}<span class="shipping"> + {{ '%.2f'|format(o.shipping_eur) }}&nbsp;€ Versand</span>{% endif %}</span>
+              <span class="price">{% if o.total_eur is number %}{{ '%.2f'|format(o.total_eur) }}&nbsp;€{% else %}–{% endif %}</span>
               {% if o.shop %}<span class="seller">{{ o.shop }}</span>{% endif %}
             </div>
-            <a class="btn btn-secondary offer-link" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot auf eBay</a>
+            <a class="btn btn-secondary offer-link" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a>
           </article>
         {% endfor %}
         {% if amazon_search_url %}
@@ -120,28 +122,6 @@
           </article>
         {% endif %}
       </div>
-
-      <table class="offer-table">
-        <thead><tr><th>Verkäufer</th><th>Preis</th><th>Versand</th><th></th></tr></thead>
-        <tbody>
-          {% for o in offers %}
-          <tr class="{% if loop.first %}top{% endif %}">
-            <td>{{ o.shop }}</td>
-            <td>{% if o.price_eur is number %}{{ '%.2f'|format(o.price_eur) }}&nbsp;€{% else %}–{% endif %}{% if loop.first %}<span class="badge-cheap">Bestpreis</span>{% endif %}</td>
-            <td>{% if o.shipping_eur is number %}{{ '%.2f'|format(o.shipping_eur) }}&nbsp;€{% else %}–{% endif %}</td>
-            <td><a class="btn btn-secondary btn-sm" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a></td>
-          </tr>
-          {% endfor %}
-          {% if amazon_search_url %}
-          <tr>
-            <td>Amazon</td>
-            <td>–</td>
-            <td>–</td>
-            <td><a class="btn btn-secondary btn-sm" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a></td>
-          </tr>
-          {% endif %}
-        </tbody>
-      </table>
     {% else %}
       <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
       {% if amazon_search_url %}


### PR DESCRIPTION
## Summary
- Render offers in a 2-column card grid with total price and compact seller info
- Add affiliate notice above offers and generic "Zum Angebot" CTA

## Testing
- `.venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab18daa6388321b853772198e24f45