### PR TITLE
Standardize 7-day price window and legend

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -14,6 +14,9 @@ EPN_CAMPAIGN_ID = os.getenv("EPN_CAMPAIGN_ID", "").strip()
 EPN_REFERENCE_ID = os.getenv("EPN_REFERENCE_ID", "preisradar").strip()
 AMAZON_PARTNER_ID = os.getenv("AMAZON_PARTNER_ID", "28310edf-21").strip()
 
+# Fenstergröße für Preisindikator (Tage)
+AVG_WINDOW_DAYS = 7
+
 env = Environment(
     loader=FileSystemLoader(str(TEMPLATES)),
     autoescape=select_autoescape(["html"])
@@ -169,7 +172,7 @@ def render_game(yaml_path, site_url):
 
     # Preisverlauf laden und Fenster berechnen
     hist = load_history(game["slug"])
-    avg7, avg_days = avg_window(hist, 7)
+    avg7, _ = avg_window(hist, AVG_WINDOW_DAYS)
     avg30, _ = avg_window(hist, 30)
 
     cutoff = dt.date.today() - dt.timedelta(days=30)
@@ -211,7 +214,7 @@ def render_game(yaml_path, site_url):
         offers=offers[:3],
         avg30=avg30,
         avg7=avg7,
-        avg_days=avg_days,
+        avg_days=AVG_WINDOW_DAYS,
         hist_days=hist_days,
         min_price=min_price,
         price_trend=price_trend,

--- a/templates/landing.html.jinja
+++ b/templates/landing.html.jinja
@@ -36,7 +36,7 @@
   </details>
   <details>
     <summary>Wie berechnet ihr den Preisindikator?</summary>
-    <p>Wir erfassen täglich den günstigsten Gesamtpreis (Preis&nbsp;+&nbsp;Versand) jedes Spiels. Aus diesen Tageswerten bilden wir einen Durchschnitt der letzten 7&nbsp;Tage und vergleichen ihn mit dem aktuellen Preis. 5&nbsp;% günstiger oder mehr = grün, etwa gleich = orange, 5&nbsp;% teurer oder mehr = rot.</p>
+    <p>Wir erfassen täglich den günstigsten Gesamtpreis (Preis&nbsp;+&nbsp;Versand) jedes Spiels und vergleichen ihn mit dem Durchschnitt der letzten 7&nbsp;Tage: ≤−5&nbsp;% gut, ±5&nbsp;% ok, ≥+5&nbsp;% teuer.</p>
   </details>
   <details>
     <summary>Was ist Brettspielpreisradar?</summary>

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -27,6 +27,8 @@
         <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
       </div>
 
+      <p class="pi-note">≤−5&nbsp;% gut / ±5&nbsp;% ok / ≥+5&nbsp;% teuer</p>
+
       <div class="pi-bar" aria-hidden="true">
         <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
       </div>
@@ -35,10 +37,6 @@
         <div><dt>Aktuell<span class="info-icon" title="Niedrigster Gesamtpreis heute inkl. Versand">ℹ</span></dt><dd id="pi-current">–</dd></div>
         <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">ℹ</span></dt><dd id="pi-avg">–</dd></div>
       </dl>
-
-      <p class="pi-note">
-        Basis ist der tägliche Gesamtpreis (Preis&nbsp;+&nbsp;Versand). Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5&nbsp;% = grün, ±5&nbsp;% = orange, ≥+5&nbsp;% = rot.
-      </p>
 
       <div class="cta-row">
         {% if offers and offers|length > 0 %}


### PR DESCRIPTION
## Summary
- Fix price indicator to always use a 7-day comparison window
- Show a concise legend above the indicator (≤−5 % gut / ±5 % ok / ≥+5 % teuer)
- Align landing page description with the new legend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab18fedc748321b40259b445b60948