### PR TITLE
feat: restructure headings and breadcrumb

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -9,6 +9,7 @@ HIST_DIR = ROOT / "data" / "history"
 TEMPLATES = ROOT / "templates"
 PUBLIC = ROOT / "public"
 DIST = ROOT / "dist"
+HUBS_CFG = ROOT / "content" / "hubs.yaml"
 
 EPN_CAMPAIGN_ID = os.getenv("EPN_CAMPAIGN_ID", "").strip()
 EPN_REFERENCE_ID = os.getenv("EPN_REFERENCE_ID", "preisradar").strip()
@@ -34,6 +35,20 @@ env.filters["md"] = simple_md
 def load_yaml(path):
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+def slugify(text):
+    text = re.sub(r"[^\w\s-]", "", str(text).lower())
+    return re.sub(r"\s+", "-", text).strip("-")
+
+# Map each game slug to its hub (title and slug)
+HUB_MAP = {}
+if HUBS_CFG.exists():
+    data = load_yaml(HUBS_CFG).get("hubs", [])
+    for h in data:
+        title = h.get("title", "")
+        hslug = slugify(title)
+        for s in h.get("slugs", []):
+            HUB_MAP[s] = {"title": title, "slug": hslug}
 
 def load_offers(slug):
     p = DATA / f"{slug}.json"
@@ -205,6 +220,22 @@ def render_game(yaml_path, site_url):
     ebay_search_url = build_epn_search_url(game)
     amazon_search_url = build_amazon_search_url(game)
 
+    hub_info = HUB_MAP.get(game["slug"])
+    if hub_info:
+        hub = {"title": hub_info["title"], "url": f"/hubs.html#{hub_info['slug']}"}
+    else:
+        hub = {"title": "Hubs", "url": "/hubs.html"}
+
+    breadcrumb = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Start", "item": f"{site_url}/"},
+            {"@type": "ListItem", "position": 2, "name": hub["title"], "item": f"{site_url}{hub['url']}"},
+            {"@type": "ListItem", "position": 3, "name": game["title"], "item": f"{site_url}/spiel/{game['slug']}/"},
+        ],
+    }
+
     page_tpl = env.get_template("page.html.jinja")
     page_html = page_tpl.render(
         game=game,
@@ -219,7 +250,9 @@ def render_game(yaml_path, site_url):
         amazon_search_url=amazon_search_url,
         history=hist30,
         history_json=json.dumps(hist30),
-        missing_fields=missing_fields
+        missing_fields=missing_fields,
+        hub=hub,
+        breadcrumb_json=json.dumps(breadcrumb, ensure_ascii=False)
     )
 
     layout_tpl = env.get_template("layout.html.jinja")
@@ -313,8 +346,9 @@ def build_hubs(site_url):
     # simple hubs page
     html = ["<h1>Themen-Hubs</h1><div class='grid two'>"]
     for h in hubs:
+        hslug = slugify(h.get('title',''))
         html.append("<div class='card'>")
-        html.append(f"<h2>{h.get('title','')}</h2>")
+        html.append(f"<h2 id='{hslug}'>{h.get('title','')}</h2>")
         if h.get("description"):
             html.append(f"<p>{h['description']}</p>")
         html.append("<ul>")

--- a/templates/games.html.jinja
+++ b/templates/games.html.jinja
@@ -1,5 +1,6 @@
 <h1>Alle Spiele</h1>
 <p>Aktuelle Angebote &amp; Preisindikator für Brettspiele. Nutze Suche oder Filter:</p>
+<h2 class="h2">Filter</h2>
 <div class="controls">
   <div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
   <details>

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -1,8 +1,8 @@
 {# ui-version:2025-08-11-v7 #}
 <article class="page">
   <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href="/alle-spiele.html">Alle Spiele</a> <span aria-hidden="true">›</span>
-    <a href="/hubs.html">Brettspiele</a> <span aria-hidden="true">›</span>
+    <a href="/">Start</a> <span aria-hidden="true">›</span>
+    {% if hub %}<a href="{{ hub.url }}">{{ hub.title }}</a> <span aria-hidden="true">›</span>{% endif %}
     <span aria-current="page">{{ game.title }}</span>
   </nav>
 
@@ -20,77 +20,6 @@
   {% if missing_fields %}
   <p class="muted">⚠️ Fehlende YAML-Werte: {{ missing_fields|join(', ') }}</p>
   {% endif %}
-  <div class="price-top">
-    <section class="price-indicator" role="group" aria-label="Preisindikator">
-      <div class="pi-header">
-        <span class="pi-title">Preisindikator</span>
-        <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
-      </div>
-
-      <div class="pi-bar" aria-hidden="true">
-        <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
-      </div>
-
-      <dl class="pi-stats">
-        <div><dt>Aktuell<span class="info-icon" title="Niedrigster Gesamtpreis heute inkl. Versand">ℹ</span></dt><dd id="pi-current">–</dd></div>
-        <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">ℹ</span></dt><dd id="pi-avg">–</dd></div>
-      </dl>
-
-      <p class="pi-note">
-        Basis ist der tägliche Gesamtpreis (Preis&nbsp;+&nbsp;Versand). Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5&nbsp;% = grün, ±5&nbsp;% = orange, ≥+5&nbsp;% = rot.
-      </p>
-
-      <div class="cta-row">
-        {% if offers and offers|length > 0 %}
-        <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
-        {% else %}
-        <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
-        {% endif %}
-      </div>
-    </section>
-
-    <section class="price-history">
-      <h2 class="h2">Preisverlauf (30 Tage)<span class="info-icon" title="Tägliche Bestpreise der letzten {{ hist_days }} Tage">ℹ</span></h2>
-      {% if avg30 %}
-        <p class="avg-price">Durchschnitt ({{ hist_days }} Tage): {{ '%.2f'|format(avg30) }}&nbsp;€</p>
-      {% else %}
-        <p class="muted">Noch keine Preisdaten.</p>
-      {% endif %}
-      <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
-    </section>
-  </div>
-
-  <section class="content-section">
-    <h2 class="h2">Kaufberatung</h2>
-    {% set primary_text = game.summary or game.description or game.about or game.intro or game.overview or game.text %}
-    {% set paragraphs = game.kaufberatung or game.paragraphs or game.extra_paragraphs %}
-    {% if primary_text %}{{ primary_text | md | safe }}{% endif %}
-    {% if paragraphs %}{% for p in paragraphs %}{{ p | md | safe }}{% endfor %}{% endif %}
-    {% if not primary_text and not paragraphs %}
-      <p class="muted">Keine Details hinterlegt – wir ergänzen diese Seite bald.</p>
-    {% endif %}
-  </section>
-
-  {% set cl = game.get('checklist') or game.get('checklist_buy') %}
-  {% if cl %}
-  <section class="content-section">
-    <h2 class="h2">Gebrauchtkauf – Checkliste</h2>
-    <ul class="checklist">
-      {% if cl is mapping %}
-        {% for k,v in cl.items() %}<li><strong>{{ k }}:</strong> {{ v }}</li>{% endfor %}
-      {% else %}
-        {% for item in cl %}
-          {% if item is mapping %}
-            {% for k,v in item.items() %}<li><strong>{{ k }}:</strong> {{ v }}</li>{% endfor %}
-          {% else %}
-            <li>{{ item }}</li>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-    </ul>
-  </section>
-  {% endif %}
-
   <section class="offers" id="angebote">
     <div class="offers-head">
       <h2 class="h2">Angebote</h2>
@@ -152,24 +81,69 @@
     {% endif %}
   </section>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script>
-  window.addEventListener('DOMContentLoaded', function(){
-    const hist = {{ history_json | safe }};
-    if(hist.length){
-      const ctx = document.getElementById('priceHistoryChart');
-      const labels = hist.map(r=>r.date);
-      const data = hist.map(r=>r.min);
-      new Chart(ctx,{type:'line',data:{labels:labels,datasets:[{label:'Preis',data:data,borderColor:'#3e95cd',fill:false}]},options:{plugins:{legend:{display:false}},scales:{y:{ticks:{callback:(v)=>v+' €'}}}}});
-    }
-    {% if min_price and avg7 %}
-    if (typeof window.renderPI === 'function'){
-      window.renderPI({current: {{ '%.2f'|format(min_price) }}, avg7: {{ '%.2f'|format(avg7) }}});
-    }
+  <section class="price-indicator" role="group" aria-label="Preisindikator">
+    <h2 class="h2">Preisindikator</h2>
+    <div class="pi-header">
+      <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
+    </div>
+
+    <div class="pi-bar" aria-hidden="true">
+      <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
+    </div>
+
+    <dl class="pi-stats">
+      <div><dt>Aktuell<span class="info-icon" title="Niedrigster Gesamtpreis heute inkl. Versand">ℹ</span></dt><dd id="pi-current">–</dd></div>
+      <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">ℹ</span></dt><dd id="pi-avg">–</dd></div>
+    </dl>
+
+    <p class="pi-note">
+      Basis ist der tägliche Gesamtpreis (Preis&nbsp;+&nbsp;Versand). Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5&nbsp;% = grün, ±5&nbsp;% = orange, ≥+5&nbsp;% = rot.
+    </p>
+
+    <div class="cta-row">
+      {% if offers and offers|length > 0 %}
+      <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
+      {% else %}
+      <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
+      {% endif %}
+    </div>
+
+    <h3>Preisverlauf (30 Tage)<span class="info-icon" title="Tägliche Bestpreise der letzten {{ hist_days }} Tage">ℹ</span></h3>
+    {% if avg30 %}
+      <p class="avg-price">Durchschnitt ({{ hist_days }} Tage): {{ '%.2f'|format(avg30) }}&nbsp;€</p>
+    {% else %}
+      <p class="muted">Noch keine Preisdaten.</p>
     {% endif %}
-  });
-  </script>
-  <script type="application/ld+json">{{ schema_json | safe }}</script>
+    <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
+  </section>
+
+  <section class="content-section">
+    <h2 class="h2">Kaufberatung</h2>
+    {% set primary_text = game.summary or game.description or game.about or game.intro or game.overview or game.text %}
+    {% set paragraphs = game.kaufberatung or game.paragraphs or game.extra_paragraphs %}
+    {% if primary_text %}{{ primary_text | md | safe }}{% endif %}
+    {% if paragraphs %}{% for p in paragraphs %}{{ p | md | safe }}{% endfor %}{% endif %}
+    {% if not primary_text and not paragraphs %}
+      <p class="muted">Keine Details hinterlegt – wir ergänzen diese Seite bald.</p>
+    {% endif %}
+    {% set cl = game.get('checklist') or game.get('checklist_buy') %}
+    {% if cl %}
+      <h3>Gebrauchtkauf – Checkliste</h3>
+      <ul class="checklist">
+        {% if cl is mapping %}
+          {% for k,v in cl.items() %}<li><strong>{{ k }}:</strong> {{ v }}</li>{% endfor %}
+        {% else %}
+          {% for item in cl %}
+            {% if item is mapping %}
+              {% for k,v in item.items() %}<li><strong>{{ k }}:</strong> {{ v }}</li>{% endfor %}
+            {% else %}
+              <li>{{ item }}</li>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      </ul>
+    {% endif %}
+  </section>
 
   {% if game.alternatives %}
   <section class="content-section">
@@ -197,6 +171,25 @@
   <section class="content-section">
     <a class="btn btn-link" href="/alle-spiele.html">← Alle Spiele</a>
   </section>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>
+  window.addEventListener('DOMContentLoaded', function(){
+    const hist = {{ history_json | safe }};
+    if(hist.length){
+      const ctx = document.getElementById('priceHistoryChart');
+      const labels = hist.map(r=>r.date);
+      const data = hist.map(r=>r.min);
+      new Chart(ctx,{type:'line',data:{labels:labels,datasets:[{label:'Preis',data:data,borderColor:'#3e95cd',fill:false}]},options:{plugins:{legend:{display:false}},scales:{y:{ticks:{callback:(v)=>v+' €'}}}}});
+    }
+    {% if min_price and avg7 %}
+    if (typeof window.renderPI === 'function'){
+      window.renderPI({current: {{ '%.2f'|format(min_price) }}, avg7: {{ '%.2f'|format(avg7) }}});
+    }
+    {% endif %}
+  });
+  </script>
+  <script type="application/ld+json">{{ breadcrumb_json | safe }}</script>
 
   {% set prices = (offers | map(attribute='price_eur') | reject('equalto', None) | list) if offers else [] %}
   {% set low = (prices|min) if prices else 0 %}


### PR DESCRIPTION
## Summary
- add hub-aware breadcrumb and JSON-LD for game pages
- ensure game pages use one H1 and four H2 sections
- expose filter heading on all-games listing

## Testing
- `python scripts/build.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab192bb984832189809e4e52ad28eb