### PR TITLE
Improve filter layout and SEO on games page

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -49,6 +49,9 @@
   var pFilter = document.getElementById('filter-players');
   var aFilter = document.getElementById('filter-age');
   var tFilter = document.getElementById('filter-theme');
+  var fStatus = document.getElementById('filter-status');
+  var resetBtn = document.getElementById('filter-reset');
+  var metaRobots = null;
 
   function applyFilters(){
     if (!list) return;
@@ -84,6 +87,19 @@
       }
       li.style.display = (textMatch && pMatch && aMatch && tMatch) ? '' : 'none';
     });
+    var hasFilter = term || players !== null || age !== null || theme;
+    if (fStatus) fStatus.hidden = !hasFilter;
+    if (hasFilter){
+      if (!metaRobots){
+        metaRobots = document.createElement('meta');
+        metaRobots.name = 'robots';
+        metaRobots.content = 'noindex,follow';
+        document.head.appendChild(metaRobots);
+      }
+    }else if (metaRobots){
+      metaRobots.remove();
+      metaRobots = null;
+    }
   }
   [q, pFilter, aFilter, tFilter].forEach(function(el){
     if (el){
@@ -91,6 +107,15 @@
       el.addEventListener('change', applyFilters);
     }
   });
+  if (resetBtn){
+    resetBtn.addEventListener('click', function(){
+      if (q) q.value = '';
+      if (pFilter) pFilter.value = '';
+      if (aFilter) aFilter.value = '';
+      if (tFilter) tFilter.value = '';
+      applyFilters();
+    });
+  }
   applyFilters();
 
   // Cookie Banner

--- a/public/styles.css
+++ b/public/styles.css
@@ -112,9 +112,13 @@ a:hover{text-decoration:underline}
 .offer-link{display:inline-flex;align-items:center}
 .search{margin:20px 0}
 .search input{width:100%;padding:14px 16px;border:1px solid var(--border);border-radius:12px;font-size:1.05rem}
-.controls{display:flex;gap:12px;align-items:flex-start;margin:20px 0}
-.controls .search{flex:1;margin:0}
-.controls details{margin:0}
+.games-layout{display:flex;flex-wrap:wrap;gap:20px;margin:20px 0}
+.filter-panel{flex:1 1 240px;max-width:300px}
+.results{flex:3 1 480px}
+@media (max-width:720px){
+  .games-layout{flex-direction:column}
+  .filter-panel{max-width:none}
+}
 .filters{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0}
 .filters label{display:flex;flex-direction:column;font-size:.95rem;flex:1 1 120px}
 .filters input,.filters select{padding:8px 10px;border:1px solid var(--border);border-radius:8px}
@@ -123,6 +127,8 @@ a:hover{text-decoration:underline}
 .game-list li{margin:6px 0}
 .game-list a{display:block;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);color:var(--text);text-decoration:none}
 .game-list a:hover{background:#f8fafc}
+.filter-status{display:flex;align-items:center;gap:8px;margin-top:12px}
+.filter-status[hidden]{display:none}
 @media (min-width:720px){ .btn-primary,.btn-secondary{width:auto} }
 
 .checklist{list-style:disc;padding-left:20px;margin:0}

--- a/templates/games.html.jinja
+++ b/templates/games.html.jinja
@@ -1,9 +1,8 @@
 <h1>Alle Spiele</h1>
 <p>Aktuelle Angebote &amp; Preisindikator für Brettspiele. Nutze Suche oder Filter:</p>
-<div class="controls">
-  <div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
-  <details>
-    <summary>Filter</summary>
+<div class="games-layout">
+  <aside class="filter-panel">
+    <div class="search"><input id="q" type="search" placeholder="Spiel suchen …" aria-label="Spiele durchsuchen"></div>
     <div class="filters">
       <label>Spieler <input id="filter-players" type="number" min="1" placeholder="z. B. 4"></label>
       <label>Alter <input id="filter-age" type="number" min="0" placeholder="z. B. 10"></label>
@@ -18,10 +17,16 @@
       </label>
       {% endif %}
     </div>
-  </details>
+    <div id="filter-status" class="filter-status" hidden>
+      <span class="chip">Filter aktiv</span>
+      <button id="filter-reset" type="button">Reset</button>
+    </div>
+  </aside>
+  <div class="results">
+    <ul class="game-list" data-list>
+    {% for g in games %}
+      <li{% if g.min_players is not none %} data-min-players="{{ g.min_players }}"{% endif %}{% if g.max_players is not none %} data-max-players="{{ g.max_players }}"{% endif %}{% if g.age is not none %} data-age="{{ g.age }}"{% endif %}{% if g.themes %} data-themes="{{ g.themes|join(',') }}"{% endif %}><a href="/spiel/{{ g.slug }}/">{{ g.title_short }}</a></li>
+    {% endfor %}
+    </ul>
+  </div>
 </div>
-<ul class="game-list" data-list>
-{% for g in games %}
-  <li{% if g.min_players is not none %} data-min-players="{{ g.min_players }}"{% endif %}{% if g.max_players is not none %} data-max-players="{{ g.max_players }}"{% endif %}{% if g.age is not none %} data-age="{{ g.age }}"{% endif %}{% if g.themes %} data-themes="{{ g.themes|join(',') }}"{% endif %}><a href="/spiel/{{ g.slug }}/">{{ g.title_short }}</a></li>
-{% endfor %}
-</ul>


### PR DESCRIPTION
## Summary
- display game filters in a sidebar with results beside them
- show "Filter aktiv" chip and reset button when filters are used
- add `noindex,follow` meta tag when filters are active

## Testing
- `pytest`
- `python scripts/build.py && echo BUILD_OK`


------
https://chatgpt.com/codex/tasks/task_e_68ab1959f20c8321b1b4239f54c4d2da