### PR TITLE
feat: add affiliate note above offers

### DIFF
--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -97,6 +97,10 @@
       <small class="muted">Sortierung nach Gesamtpreis (aufsteigend), nur Angebote in EUR.</small>
     </div>
 
+    {% if game.disclosure %}
+      <p class="muted affiliate-note">{{ game.disclosure }}</p>
+    {% endif %}
+
     {% if offers and offers|length > 0 %}
       <div class="offer-grid">
         {% for o in offers %}


### PR DESCRIPTION
## Summary
- show affiliate disclosure above offers list on game pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab197aecec8321ad43acf46beabfee