### PR TITLE
Refactor game page layout for improved CTR

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -111,3 +111,9 @@
     showStatus('Einstellungen gespeichert.');
   });
 })();
+
+function click_offer(merchant, slug, price){
+  if(window.gtag){
+    gtag('event','click_offer',{merchant:merchant,slug:slug,price:price});
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -79,6 +79,7 @@ a:hover{text-decoration:underline}
 .bp-shop{font-size:1rem;font-weight:600}
 .bp-time{font-size:.85rem;color:var(--muted)}
 .bp-indicator{margin:0;font-size:.95rem}
+.bp-badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:4px}
 
 /* Price Indicator */
 .price-indicator{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:var(--pi-fg)}
@@ -173,6 +174,11 @@ a:hover{text-decoration:underline}
 .footer-inner{padding:20px 16px}
 .muted{color:var(--muted)}
 .affiliate-note{font-size:.8rem;margin:8px 0}
+
+.sticky-buy-bar{position:fixed;bottom:0;left:0;right:0;background:var(--panel);border-top:1px solid var(--border);box-shadow:var(--shadow);padding:10px;display:none;z-index:60}
+.sticky-buy-bar.show{display:flex}
+.sticky-buy-bar .btn{width:100%}
+@media(min-width:720px){.sticky-buy-bar{display:none!important}}
 
 .cookie-banner{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:#fff;color:var(--text);border-top:1px solid var(--border);box-shadow:var(--shadow);padding:16px 20px;display:none;flex-direction:column;align-items:center;gap:16px;font-size:.9rem;text-align:center;border-radius:12px 12px 0 0}
 .cookie-banner .cookie-actions{display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -1,4 +1,5 @@
 {# ui-version:2025-08-11-v7 #}
+{% set best = (offers[0] if offers else None) %}
 <article class="page">
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="/">Start</a> <span aria-hidden="true">›</span>
@@ -8,29 +9,18 @@
 
   <header class="hero">
     <h1 class="title">{{ game.title }}</h1>
-    {% if game.subtitle %}<p class="subtitle">{{ game.subtitle }}</p>{% endif %}
-    {% if offers and offers|length > 0 %}
-    {% set best = offers[0] %}
-    <section class="best-price" aria-label="Bestpreis">
-      <div class="bp-main">
-        <span class="bp-price">{{ '%.2f'|format(best.total_eur or best.price_eur) }}&nbsp;€</span>
-        {% if best.shop %}<span class="bp-shop">{{ best.shop }}</span>{% endif %}
-        {% if last_checked %}<span class="bp-time">Zuletzt geprüft: {{ last_checked.strftime('%d.%m.%Y %H:%M') }} Uhr</span>{% endif %}
-      </div>
-      <a class="btn btn-primary" href="{{ best.url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt zum Deal</a>
-      {% if min_price and avg7 %}
-        {% set diff = ((min_price - avg7) / avg7 * 100) %}
-        {% if diff <= -5 %}
-          <p class="bp-indicator">🟢 {{ diff|abs|round(0) }}% unter 7‑Tage-Ø</p>
-        {% elif diff < 5 %}
-          <p class="bp-indicator">🟠 etwa auf 7‑Tage-Ø</p>
-        {% else %}
-          <p class="bp-indicator">🔴 {{ diff|abs|round(0) }}% über 7‑Tage-Ø</p>
+    <ul class="chips">
+      {% if game.editions and game.editions.recommended %}
+        {% set parts = game.editions.recommended.split('(') %}
+        {% set edition = parts[0].strip() %}
+        {% if edition %}<li class="chip">{{ edition }}</li>{% endif %}
+        {% if parts|length > 1 %}
+          {% set lang_raw = parts[1].replace(')', '').strip().lower() %}
+          {% set lang_map = {'deutsch':'DE','de':'DE','englisch':'EN','en':'EN'} %}
+          {% set lang = lang_map.get(lang_raw, lang_raw|upper) %}
+          {% if lang %}<li class="chip">{{ lang }}</li>{% endif %}
         {% endif %}
       {% endif %}
-    </section>
-    {% endif %}
-    <ul class="chips">
       {% if game.players %}<li class="chip">👥 {{ game.players.min }}–{{ game.players.max }} Spieler</li>{% endif %}
       {% if game.playtime %}<li class="chip">⏱️ {{ game.playtime.min }}–{{ game.playtime.max }} Min</li>{% endif %}
       {% if game.complexity %}<li class="chip">🧠 Komplexität {{ '%.1f'|format(game.complexity) }}</li>{% endif %}
@@ -38,17 +28,71 @@
     </ul>
   </header>
 
+  {% if best %}
+  {% set diff = ((min_price - avg7) / avg7 * 100) if (min_price and avg7) else None %}
+  <section class="best-price" aria-label="Bestpreis">
+    <div class="bp-main">
+      <span class="bp-price">{{ '%.2f'|format(best.total_eur or best.price_eur) }}&nbsp;€</span>
+      {% if best.shop %}<span class="bp-shop">{{ best.shop }}</span>{% endif %}
+      {% if last_checked %}<span class="bp-time">Zuletzt geprüft: {{ last_checked.strftime('%d.%m.%Y %H:%M') }} Uhr</span>{% endif %}
+    </div>
+    {% set sep = '?' if '?' not in best.url else '&' %}
+    <a class="btn btn-primary" href="{{ best.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" onclick="click_offer('{{ best.shop }}','{{ game.slug }}','{{ '%.2f'|format(best.total_eur or best.price_eur) }}')" target="_blank" rel="nofollow sponsored noopener">Jetzt zum Deal bei {{ best.shop }}</a>
+    {% if diff is not none %}
+    <div class="bp-badges">
+      <span class="badge-grey">−{{ diff|abs|round(0) }}% vs. 7‑Tage‑Ø</span>
+      {% if is_best_90 %}<span class="badge-grey">Bestpreis (90 Tage)</span>{% endif %}
+    </div>
+    {% endif %}
+  </section>
+  {% endif %}
+
   {% if missing_fields %}
   <p class="muted">⚠️ Fehlende YAML-Werte: {{ missing_fields|join(', ') }}</p>
   {% endif %}
+
+  <section class="offers" id="angebote">
+    <div class="offers-head">
+      <h2 class="h2">Preisvergleich</h2>
+    </div>
+    <p class="affiliate-note muted">Hinweis: Links mit „Zum Angebot“ sind Affiliate-Links.</p>
+    {% if offers and offers|length > 0 %}
+    <div class="offer-grid">
+      {% for o in offers %}
+        {% set extra = loop.index > 4 %}
+        {% set sep = '?' if '?' not in o.url else '&' %}
+        <article class="offer-card{% if loop.first %} top{% endif %}{% if extra %} extra{% endif %}" {% if extra %}style="display:none"{% endif %} data-offer>
+          {% if loop.first %}<div class="badge">Bestpreis</div>{% endif %}
+          {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
+          <h3 class="offer-title"><a href="{{ o.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a></h3>
+          <div class="offer-meta">
+            <span class="price">{% if o.total_eur is number %}{{ '%.2f'|format(o.total_eur) }}&nbsp;€{% else %}–{% endif %}</span>
+            {% if o.condition %}<span class="condition">{{ o.condition }}</span>{% endif %}
+            {% if o.shop %}<span class="seller">{{ o.shop }}</span>{% endif %}
+          </div>
+          <a class="btn btn-secondary offer-link" href="{{ o.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" onclick="click_offer('{{ o.shop }}','{{ game.slug }}','{{ o.total_eur or o.price_eur }}')" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a>
+        </article>
+      {% endfor %}
+    </div>
+    {% if offers|length > 4 %}
+    <div class="cta-row"><button id="moreOffersBtn" class="btn btn-link">Weitere Angebote anzeigen</button></div>
+    {% endif %}
+    {% else %}
+      <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
+      {% if amazon_search_url %}
+      <div class="cta-row">
+        <a class="btn btn-secondary" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a>
+      </div>
+      {% endif %}
+    {% endif %}
+  </section>
+
   <div class="price-top">
     <section class="price-indicator" role="group" aria-label="Preisindikator">
       <div class="pi-header">
         <span class="pi-title">Preisindikator</span>
         <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
       </div>
-
-      <p class="pi-note">≤−5&nbsp;% gut / ±5&nbsp;% ok / ≥+5&nbsp;% teuer</p>
 
       <div class="pi-bar" aria-hidden="true">
         <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
@@ -59,24 +103,19 @@
         <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">ℹ</span></dt><dd id="pi-avg">–</dd></div>
       </dl>
 
-      <div class="cta-row">
-        {% if offers and offers|length > 0 %}
-        <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
-        {% else %}
-        <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
-        {% endif %}
-      </div>
+      <p class="pi-note">Basis: Tages-Bestpreis inkl. Versand vs. Ø der letzten 7 Tage.</p>
     </section>
 
-  <section class="price-history">
-    <h2 class="h2">Preisverlauf (30 Tage)<span class="info-icon" title="Tägliche Bestpreise der letzten {{ hist_days }} Tage">ℹ</span></h2>
-    {% if avg30 %}
-      <p class="avg-price">Durchschnitt ({{ hist_days }} Tage): {{ '%.2f'|format(avg30) }}&nbsp;€</p>
-    {% else %}
-      <p class="muted">Noch keine Preisdaten.</p>
-    {% endif %}
-    <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
-  </section>
+    <section class="price-history">
+      <h2 class="h2">Preisverlauf (30 Tage)<span class="info-icon" title="Tägliche Bestpreise der letzten {{ hist_days }} Tage">ℹ</span></h2>
+      {% if avg30 %}
+        <p class="avg-price">Durchschnitt ({{ hist_days }} Tage): {{ '%.2f'|format(avg30) }}&nbsp;€</p>
+      {% else %}
+        <p class="muted">Noch keine Preisdaten.</p>
+      {% endif %}
+      <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
+    </section>
+  </div>
 
   <section class="content-section">
     <h2 class="h2">Kaufberatung</h2>
@@ -108,110 +147,6 @@
     </ul>
   </section>
   {% endif %}
-  <section class="offers" id="angebote">
-    <div class="offers-head">
-      <h2 class="h2">Angebote</h2>
-      <small class="muted">Sortierung nach Gesamtpreis (aufsteigend), nur Angebote in EUR.{% if fetched_at %} – aktualisiert {{ fetched_at }}{% endif %}</small>
-    </div>
-
-    <p class="affiliate-note muted">Transparenz: Links mit „Zum Angebot“ sind Affiliate-Links. Kaufst du darüber, erhalten wir ggf. eine Provision – für dich bleibt der Preis gleich.</p>
-
-    {% if offers and offers|length > 0 %}
-      <div class="offer-grid">
-        {% for o in offers %}
-          {% set is_best = loop.first %}
-          <article class="offer-card{% if is_best %} top{% endif %}" data-offer>
-            {% if is_best %}<div class="badge">Bestpreis</div>{% endif %}
-            {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
-            <h3 class="offer-title"><a href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a></h3>
-            <div class="offer-meta">
-              <span class="price">{% if o.total_eur is number %}{{ '%.2f'|format(o.total_eur) }}&nbsp;€{% else %}–{% endif %}</span>
-              {% if o.shop %}<span class="seller">{{ o.shop }}</span>{% endif %}
-            </div>
-            <a class="btn btn-secondary offer-link" href="{{ o.url }}" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a>
-          </article>
-        {% endfor %}
-        {% if amazon_search_url %}
-          <article class="offer-card" data-offer>
-            <h3 class="offer-title"><a href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Amazon</a></h3>
-            <div class="offer-meta"><span class="price">–</span></div>
-            <a class="btn btn-secondary offer-link" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a>
-          </article>
-        {% endif %}
-      </div>
-    {% else %}
-      <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
-      {% if amazon_search_url %}
-      <div class="cta-row">
-        <a class="btn btn-secondary" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a>
-      </div>
-      {% endif %}
-    {% endif %}
-  </section>
-
-  <section class="price-indicator" role="group" aria-label="Preisindikator">
-    <h2 class="h2">Preisindikator</h2>
-    <div class="pi-header">
-      <span class="pi-badge" id="pi-badge" aria-live="polite">–</span>
-    </div>
-
-    <div class="pi-bar" aria-hidden="true">
-      <div class="pi-marker" id="pi-marker" title="Aktueller Preis"></div>
-    </div>
-
-    <dl class="pi-stats">
-      <div><dt>Aktuell<span class="info-icon" title="Niedrigster Gesamtpreis heute inkl. Versand">ℹ</span></dt><dd id="pi-current">–</dd></div>
-      <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">ℹ</span></dt><dd id="pi-avg">–</dd></div>
-    </dl>
-
-    <p class="pi-note">
-      Basis ist der tägliche Gesamtpreis (Preis&nbsp;+&nbsp;Versand). Wir vergleichen den aktuellen Bestpreis mit dem Durchschnitt der letzten {{ avg_days }} Tage. ≤−5&nbsp;% = grün, ±5&nbsp;% = orange, ≥+5&nbsp;% = rot.
-    </p>
-
-    <div class="cta-row">
-      {% if offers and offers|length > 0 %}
-      <a class="btn btn-primary" href="#angebote" onclick="document.getElementById('angebote').scrollIntoView({behavior:'smooth'});return false;">Jetzt Angebote ansehen</a>
-      {% else %}
-      <a class="btn btn-primary" href="{{ ebay_search_url }}" target="_blank" rel="nofollow sponsored noopener">Jetzt Angebote ansehen</a>
-      {% endif %}
-    </div>
-
-    <h3>Preisverlauf (30 Tage)<span class="info-icon" title="Tägliche Bestpreise der letzten {{ hist_days }} Tage">ℹ</span></h3>
-    {% if avg30 %}
-      <p class="avg-price">Durchschnitt ({{ hist_days }} Tage): {{ '%.2f'|format(avg30) }}&nbsp;€</p>
-    {% else %}
-      <p class="muted">Noch keine Preisdaten.</p>
-    {% endif %}
-    <div class="price-chart"><canvas id="priceHistoryChart"></canvas></div>
-  </section>
-
-  <section class="content-section">
-    <h2 class="h2">Kaufberatung</h2>
-    {% set primary_text = game.summary or game.description or game.about or game.intro or game.overview or game.text %}
-    {% set paragraphs = game.kaufberatung or game.paragraphs or game.extra_paragraphs %}
-    {% if primary_text %}{{ primary_text | md | safe }}{% endif %}
-    {% if paragraphs %}{% for p in paragraphs %}{{ p | md | safe }}{% endfor %}{% endif %}
-    {% if not primary_text and not paragraphs %}
-      <p class="muted">Keine Details hinterlegt – wir ergänzen diese Seite bald.</p>
-    {% endif %}
-    {% set cl = game.get('checklist') or game.get('checklist_buy') %}
-    {% if cl %}
-      <h3>Gebrauchtkauf – Checkliste</h3>
-      <ul class="checklist">
-        {% if cl is mapping %}
-          {% for k,v in cl.items() %}<li><strong>{{ k }}:</strong> {{ v }}</li>{% endfor %}
-        {% else %}
-          {% for item in cl %}
-            {% if item is mapping %}
-              {% for k,v in item.items() %}<li><strong>{{ k }}:</strong> {{ v }}</li>{% endfor %}
-            {% else %}
-              <li>{{ item }}</li>
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-      </ul>
-    {% endif %}
-  </section>
 
   {% if game.alternatives %}
   <section class="content-section">
@@ -236,9 +171,30 @@
   </section>
   {% endif %}
 
+  {% if game.faqs %}
+  <section class="content-section faq">
+    <h2 class="h2">FAQ</h2>
+    <div class="faq">
+      {% for f in game.faqs %}
+      <details>
+        <summary>{{ f.q }}</summary>
+        <div class="answer">{{ f.a }}</div>
+      </details>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
   <section class="content-section">
     <a class="btn btn-link" href="/alle-spiele.html">← Alle Spiele</a>
   </section>
+
+  {% if best %}
+  {% set sep = '?' if '?' not in best.url else '&' %}
+  <div class="sticky-buy-bar" id="stickyBuyBar">
+    <a class="btn btn-primary" href="{{ best.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" onclick="click_offer('{{ best.shop }}','{{ game.slug }}','{{ '%.2f'|format(best.total_eur or best.price_eur) }}')" target="_blank" rel="nofollow sponsored noopener">Jetzt zum Deal bei {{ best.shop }}</a>
+  </div>
+  {% endif %}
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
@@ -252,9 +208,26 @@
     }
     {% if min_price and avg7 %}
     if (typeof window.renderPI === 'function'){
-      window.renderPI({current: {{ '%.2f'|format(min_price) }}, avg7: {{ '%.2f'|format(avg7) }}});
+      window.renderPI({current: {{ '%.2f'|format(min_price) }}, avg7: {{ '%.2f'|format(avg7) }}} );
     }
     {% endif %}
+    var moreBtn=document.getElementById('moreOffersBtn');
+    if(moreBtn){
+      moreBtn.addEventListener('click',function(){
+        document.querySelectorAll('.offer-card.extra').forEach(function(el){ el.style.display='flex'; });
+        moreBtn.remove();
+      });
+    }
+    var sticky=document.getElementById('stickyBuyBar');
+    var hero=document.querySelector('.hero');
+    if(sticky && hero){
+      var observer=new IntersectionObserver(function(entries){
+        entries.forEach(function(entry){
+          if(entry.isIntersecting){ sticky.classList.remove('show'); } else { sticky.classList.add('show'); }
+        });
+      });
+      observer.observe(hero);
+    }
   });
   </script>
   <script type="application/ld+json">{{ breadcrumb_json | safe }}</script>


### PR DESCRIPTION
## Summary
- Restructure game landing page to follow recommended deal-first flow
- Add best price bar badges, sticky buy bar and expandable offer list
- Implement click tracking helper and related styles
- Wrap price indicator and chart in a flex container for proper desktop layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb28de49c8321b0f124c5770353bc