### PR TITLE
Handle offer metadata in label server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,29 @@ Setze optional die Umgebungsvariable `AMAZON_PARTNER_ID` (Standard `28310edf-21`
 
 **YAML Felder (neu & optional)**
 - `how_to_play_60s` (Text), `used_checklist` (Liste), `editions` (note/recommended/avoid), `expansions` (Liste mit name/verdict), `pros`/`cons` (Listen).
+
+## Relevanz-Training für eBay-Angebote
+
+Um irrelevante Treffer aus den eBay-Suchergebnissen zu filtern, gibt es einen
+kleinen Trainingsworkflow:
+
+1. **Angebote labeln**
+
+   - Lege die Umgebungsvariablen `TRAINING_USER` und `TRAINING_PASS` an
+     (z. B. als GitHub Secret).
+   - Starte den kleinen Server:
+     ```bash
+     python scripts/label_server.py
+     ```
+   - Rufe im Browser `http://localhost:8000/spiel/<slug>/training` auf und markiere die
+     angezeigten Angebote als „relevant“ oder „nicht relevant“. Die Labels
+     werden in `data/labels/<slug>.json` gespeichert.
+
+2. **Modell trainieren**
+
+   ```bash
+   python scripts/train_relevance_model.py
+   ```
+
+   Es entsteht `data/relevance_model.pkl`, das beim nächsten `build.py`
+   automatisch geladen wird. Nicht relevante Angebote werden dann verworfen.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /spiel/*/training

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Jinja2==3.1.4
 PyYAML==6.0.2
 requests==2.32.3
 python-dotenv==1.0.1
+Flask==3.0.3
+scikit-learn==1.4.2

--- a/scripts/label_server.py
+++ b/scripts/label_server.py
@@ -1,0 +1,132 @@
+"""Small Flask server to label eBay offers as relevant or not.
+
+This tool is meant for manual training.  It exposes a single page per game
+where the top offers of the last fetch are shown.  Each offer can be labelled
+"relevant" or "nicht relevant" and the result is stored in
+``data/labels/<slug>.json``.  The page is protected via HTTP basic
+authentication; credentials are read from the environment variables
+``TRAINING_USER`` and ``TRAINING_PASS`` which should be stored as GitHub
+secrets for deployments.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+from functools import wraps
+
+from flask import Flask, abort, jsonify, render_template_string, request, make_response
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+OFFERS_DIR = ROOT / "data" / "offers"
+LABEL_DIR = ROOT / "data" / "labels"
+LABEL_DIR.mkdir(parents=True, exist_ok=True)
+
+USER = os.getenv("TRAINING_USER", "")
+PASSWORD = os.getenv("TRAINING_PASS", "")
+
+app = Flask(__name__)
+
+
+def check_auth(username: str, password: str) -> bool:
+    return username == USER and password == PASSWORD
+
+
+def authenticate():
+    return (
+        "Authentication required",
+        401,
+        {"WWW-Authenticate": 'Basic realm="Login Required"'},
+    )
+
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+            return authenticate()
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+@app.route("/spiel/<slug>/training", methods=["GET"])
+@requires_auth
+def label_page(slug: str):
+    offers_file = OFFERS_DIR / f"{slug}.json"
+    if not offers_file.exists():
+        abort(404)
+    data = json.loads(offers_file.read_text("utf-8"))
+    if isinstance(data, dict):
+        offers = data.get("offers", [])
+    else:
+        offers = data
+    offers = offers[:100]
+    label_file = LABEL_DIR / f"{slug}.json"
+    labels = {}
+    if label_file.exists():
+        labels = json.loads(label_file.read_text("utf-8"))
+
+    html = """
+<!doctype html>
+<title>Label offers – {{ slug }}</title>
+<meta name="robots" content="noindex, nofollow">
+<h1>Label offers for {{ slug }}</h1>
+<div id="offers"></div>
+<script>
+const offers = {{ offers | tojson }};
+const labels = {{ labels | tojson }};
+function sendLabel(id, val){
+  fetch('', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({id:id, label:val})});
+}
+function render(){
+  const container=document.getElementById('offers');
+  container.innerHTML='';
+  offers.forEach(o=>{
+    const id=o.itemId || o.id || o.url;
+    const div=document.createElement('div');
+    div.innerHTML = `<p><a href="${o.url}" target="_blank">${o.title||id}</a>` +
+      ` – ${o.total_eur||o.price_eur||''} € – <strong>${labels[id]}</strong></p>`;
+    const rel=document.createElement('button');
+    rel.textContent='relevant';
+    rel.onclick=()=>{labels[id]=true; sendLabel(id,true); render();};
+    const nrel=document.createElement('button');
+    nrel.textContent='nicht relevant';
+    nrel.onclick=()=>{labels[id]=false; sendLabel(id,false); render();};
+    div.appendChild(rel); div.appendChild(nrel);
+    container.appendChild(div);
+  });
+}
+render();
+</script>
+"""
+    response = make_response(
+        render_template_string(html, slug=slug, offers=offers, labels=labels)
+    )
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return response
+
+
+@app.route("/spiel/<slug>/training", methods=["POST"])
+@requires_auth
+def save_label(slug: str):
+    data = request.get_json(force=True) or {}
+    item_id = str(data.get("id"))
+    label = bool(data.get("label"))
+    label_file = LABEL_DIR / f"{slug}.json"
+    labels = {}
+    if label_file.exists():
+        labels = json.loads(label_file.read_text("utf-8"))
+    labels[item_id] = label
+    label_file.write_text(json.dumps(labels, ensure_ascii=False, indent=2), "utf-8")
+    resp = jsonify({"status": "ok"})
+    resp.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return resp
+
+
+if __name__ == "__main__":
+    app.run(port=8000, debug=True)
+

--- a/scripts/train_relevance_model.py
+++ b/scripts/train_relevance_model.py
@@ -1,0 +1,65 @@
+"""Train a tiny text classifier to filter irrelevant eBay offers.
+
+The script expects labelled offers in ``data/labels`` generated via
+``scripts/label_server.py`` and the corresponding raw offers in
+``data/offers``.  A simple ``TfidfVectorizer`` + ``LogisticRegression``
+pipeline is used.  The resulting model is saved to
+``data/relevance_model.pkl`` and automatically used during ``build.py`` to
+filter offers.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+OFFERS_DIR = ROOT / "data" / "offers"
+LABEL_DIR = ROOT / "data" / "labels"
+MODEL_PATH = ROOT / "data" / "relevance_model.pkl"
+
+
+def load_dataset():
+    texts, labels = [], []
+    for label_file in LABEL_DIR.glob("*.json"):
+        slug = label_file.stem
+        offers_file = OFFERS_DIR / f"{slug}.json"
+        if not offers_file.exists():
+            continue
+        offers = json.loads(offers_file.read_text("utf-8"))
+        label_map = json.loads(label_file.read_text("utf-8"))
+        for offer in offers:
+            item_id = str(offer.get("itemId") or offer.get("id") or offer.get("url") or "")
+            if not item_id or item_id not in label_map:
+                continue
+            text = " ".join(
+                str(offer.get(k, ""))
+                for k in ["title", "subtitle", "condition", "shop", "description"]
+            )
+            texts.append(text)
+            labels.append(1 if label_map[item_id] else 0)
+    return texts, labels
+
+
+def main():
+    texts, y = load_dataset()
+    if not texts:
+        print("No labelled data found")
+        return
+    vec = TfidfVectorizer(max_features=5000)
+    X = vec.fit_transform(texts)
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X, y)
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump({"vectorizer": vec, "model": model}, MODEL_PATH)
+    print(f"Saved model to {MODEL_PATH}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Avoid KeyError in training interface by handling JSON metadata structure when loading offers

## Testing
- `pytest -q`
- `python scripts/train_relevance_model.py` *(no labelled data found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaec76e4083218a7167aba0fc198a