### PR TITLE
fix: robust JSON parsing for labeling server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,30 @@ Setze optional die Umgebungsvariable `AMAZON_PARTNER_ID` (Standard `28310edf-21`
 
 **YAML Felder (neu & optional)**
 - `how_to_play_60s` (Text), `used_checklist` (Liste), `editions` (note/recommended/avoid), `expansions` (Liste mit name/verdict), `pros`/`cons` (Listen).
+
+## Relevanz-Training für eBay-Angebote
+
+Um irrelevante Treffer aus den eBay-Suchergebnissen zu filtern, gibt es einen
+kleinen Trainingsworkflow:
+
+1. **Angebote labeln**
+
+   - Lege die Umgebungsvariablen `TRAINING_USER` und `TRAINING_PASS` an
+     (z. B. als GitHub Secret).
+   - Starte den kleinen Server:
+     ```bash
+     python scripts/label_server.py
+     ```
+   - Rufe im Browser `http://localhost:8000/spiel/<slug>/training` auf und markiere die
+     angezeigten Angebote als „relevant“ oder „nicht relevant“. Die Labels
+    werden in `data/labels/<slug>.json` gespeichert. Fehler beim Einlesen
+    der Angebote landen samt Stacktrace in `data/logs/label_server.log`.
+
+2. **Modell trainieren**
+
+   ```bash
+   python scripts/train_relevance_model.py
+   ```
+
+   Es entsteht `data/relevance_model.pkl`, das beim nächsten `build.py`
+   automatisch geladen wird. Nicht relevante Angebote werden dann verworfen.

--- a/data/logs/label_server.log
+++ b/data/logs/label_server.log
@@ -1,0 +1,6 @@
+2025-08-27T08:05:12 ERROR failed to load offers for catan
+Traceback (most recent call last):
+  File "scripts/label_server.py", line 62, in label_page
+    offers = json.loads(offers_file.read_text("utf-8"))[:100]
+KeyError: slice(None, 100, None)
+2025-08-27 09:05:45,897 INFO loaded /workspace/brettspielradar/data/offers/sample.json with root type dict

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /spiel/*/training

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Jinja2==3.1.4
 PyYAML==6.0.2
 requests==2.32.3
 python-dotenv==1.0.1
+Flask==3.0.3
+scikit-learn==1.4.2

--- a/scripts/label_server.py
+++ b/scripts/label_server.py
@@ -1,0 +1,173 @@
+"""Small Flask server to label eBay offers as relevant or not.
+
+This tool is meant for manual training.  It exposes a single page per game
+where the top offers of the last fetch are shown.  Each offer can be labelled
+"relevant" or "nicht relevant" and the result is stored in
+``data/labels/<slug>.json``.  The page is protected via HTTP basic
+authentication; credentials are read from the environment variables
+``TRAINING_USER`` and ``TRAINING_PASS`` which should be stored as GitHub
+secrets for deployments.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+from functools import wraps
+
+from flask import Flask, abort, jsonify, render_template_string, request, make_response
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+OFFERS_DIR = ROOT / "data" / "offers"
+LABEL_DIR = ROOT / "data" / "labels"
+LOG_DIR = ROOT / "data" / "logs"
+for d in (LABEL_DIR, LOG_DIR):
+    d.mkdir(parents=True, exist_ok=True)
+
+LOG_FILE = LOG_DIR / "label_server.log"
+
+file_handler = logging.FileHandler(LOG_FILE)
+file_handler.setFormatter(
+    logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+)
+app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+app.logger.addHandler(file_handler)
+
+USER = os.getenv("TRAINING_USER", "")
+PASSWORD = os.getenv("TRAINING_PASS", "")
+
+
+def check_auth(username: str, password: str) -> bool:
+    return username == USER and password == PASSWORD
+
+
+def authenticate():
+    return (
+        "Authentication required",
+        401,
+        {"WWW-Authenticate": 'Basic realm="Login Required"'},
+    )
+
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+            return authenticate()
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+@app.route("/spiel/<slug>/training", methods=["GET"])
+@requires_auth
+def label_page(slug: str):
+    offers_file = OFFERS_DIR / f"{slug}.json"
+    if not offers_file.exists():
+        abort(404)
+    try:
+        data = json.loads(offers_file.read_text("utf-8"))
+        app.logger.info("loaded %s with root type %s", offers_file, type(data).__name__)
+        # ``fetch_offers_ebay_enhanced.py`` stores either a plain list of offers
+        # or a dictionary with an ``offers`` key.  Older files might still use the
+        # eBay API's ``searchResult.item`` structure.  Instead of slicing the raw
+        # JSON (which would raise ``KeyError: slice(None, 100, None)`` when the
+        # root object is a dictionary) we normalise the structure here and always
+        # operate on a list.
+        if isinstance(data, dict):
+            # Prefer the plain ``offers`` list if present
+            offers = data.get("offers")
+            if offers is None:
+                # Fall back to the eBay API format: {"searchResult": {"item": [...]}}
+                offers = data.get("searchResult", {}).get("item")
+            if offers is None:
+                # Some legacy dumps were a plain dict keyed by numbers
+                offers = data
+        else:
+            offers = data
+        # eBay's ``searchResult.item`` or legacy dumps may still be dictionaries
+        # keyed by numbers.  Convert them to a list before slicing.
+        if isinstance(offers, dict):
+            offers = list(offers.values())
+        if not isinstance(offers, list):
+            offers = []
+        offers = offers[:100]
+    except Exception:  # pragma: no cover - logging full stack for debugging
+        app.logger.exception("failed to load offers for %s", slug)
+        abort(500)
+    label_file = LABEL_DIR / f"{slug}.json"
+    labels = {}
+    if label_file.exists():
+        labels = json.loads(label_file.read_text("utf-8"))
+
+    html = """
+<!doctype html>
+<title>Label offers – {{ slug }}</title>
+<meta name="robots" content="noindex, nofollow">
+<h1>Label offers for {{ slug }}</h1>
+<div id="offers"></div>
+<script>
+const offers = {{ offers | tojson }};
+const labels = {{ labels | tojson }};
+function sendLabel(id, val){
+  fetch('', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({id:id, label:val})});
+}
+function render(){
+  const container=document.getElementById('offers');
+  container.innerHTML='';
+  offers.forEach(o=>{
+    const id=o.itemId || o.id || o.url;
+    const div=document.createElement('div');
+    div.innerHTML = `<p><a href="${o.url}" target="_blank">${o.title||id}</a>` +
+      ` – ${o.total_eur||o.price_eur||''} € – <strong>${labels[id]}</strong></p>`;
+    const rel=document.createElement('button');
+    rel.textContent='relevant';
+    rel.onclick=()=>{labels[id]=true; sendLabel(id,true); render();};
+    const nrel=document.createElement('button');
+    nrel.textContent='nicht relevant';
+    nrel.onclick=()=>{labels[id]=false; sendLabel(id,false); render();};
+    div.appendChild(rel); div.appendChild(nrel);
+    container.appendChild(div);
+  });
+}
+render();
+</script>
+"""
+    response = make_response(
+        render_template_string(html, slug=slug, offers=offers, labels=labels)
+    )
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return response
+
+
+@app.route("/spiel/<slug>/training", methods=["POST"])
+@requires_auth
+def save_label(slug: str):
+    try:
+        data = request.get_json(force=True) or {}
+        item_id = str(data.get("id"))
+        label = bool(data.get("label"))
+        label_file = LABEL_DIR / f"{slug}.json"
+        labels = {}
+        if label_file.exists():
+            labels = json.loads(label_file.read_text("utf-8"))
+        labels[item_id] = label
+        label_file.write_text(
+            json.dumps(labels, ensure_ascii=False, indent=2), "utf-8"
+        )
+        resp = jsonify({"status": "ok"})
+        resp.headers["X-Robots-Tag"] = "noindex, nofollow"
+        return resp
+    except Exception:  # pragma: no cover - debugging write errors
+        app.logger.exception("failed to save label for %s", slug)
+        abort(500)
+
+
+if __name__ == "__main__":
+    app.run(port=8000, debug=True)
+

--- a/scripts/train_relevance_model.py
+++ b/scripts/train_relevance_model.py
@@ -1,0 +1,65 @@
+"""Train a tiny text classifier to filter irrelevant eBay offers.
+
+The script expects labelled offers in ``data/labels`` generated via
+``scripts/label_server.py`` and the corresponding raw offers in
+``data/offers``.  A simple ``TfidfVectorizer`` + ``LogisticRegression``
+pipeline is used.  The resulting model is saved to
+``data/relevance_model.pkl`` and automatically used during ``build.py`` to
+filter offers.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+OFFERS_DIR = ROOT / "data" / "offers"
+LABEL_DIR = ROOT / "data" / "labels"
+MODEL_PATH = ROOT / "data" / "relevance_model.pkl"
+
+
+def load_dataset():
+    texts, labels = [], []
+    for label_file in LABEL_DIR.glob("*.json"):
+        slug = label_file.stem
+        offers_file = OFFERS_DIR / f"{slug}.json"
+        if not offers_file.exists():
+            continue
+        offers = json.loads(offers_file.read_text("utf-8"))
+        label_map = json.loads(label_file.read_text("utf-8"))
+        for offer in offers:
+            item_id = str(offer.get("itemId") or offer.get("id") or offer.get("url") or "")
+            if not item_id or item_id not in label_map:
+                continue
+            text = " ".join(
+                str(offer.get(k, ""))
+                for k in ["title", "subtitle", "condition", "shop", "description"]
+            )
+            texts.append(text)
+            labels.append(1 if label_map[item_id] else 0)
+    return texts, labels
+
+
+def main():
+    texts, y = load_dataset()
+    if not texts:
+        print("No labelled data found")
+        return
+    vec = TfidfVectorizer(max_features=5000)
+    X = vec.fit_transform(texts)
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X, y)
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump({"vectorizer": vec, "model": model}, MODEL_PATH)
+    print(f"Saved model to {MODEL_PATH}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_label_server.py
+++ b/tests/test_label_server.py
@@ -1,0 +1,73 @@
+import base64
+import json
+import logging
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import label_server
+
+
+def _auth_header(user="u", password="p"):
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def test_label_page_handles_searchresult_dict(tmp_path, monkeypatch):
+    offers_dir = tmp_path / "data" / "offers"
+    labels_dir = tmp_path / "data" / "labels"
+    logs_dir = tmp_path / "data" / "logs"
+    for d in (offers_dir, labels_dir, logs_dir):
+        d.mkdir(parents=True)
+
+    slug = "game"
+    offers_file = offers_dir / f"{slug}.json"
+    offers_file.write_text(
+        json.dumps({"searchResult": {"item": {"0": {"itemId": "1", "url": "u", "title": "t"}}}}),
+        "utf-8",
+    )
+
+    monkeypatch.setattr(label_server, "OFFERS_DIR", offers_dir)
+    monkeypatch.setattr(label_server, "LABEL_DIR", labels_dir)
+    monkeypatch.setattr(label_server, "LOG_DIR", logs_dir)
+    monkeypatch.setattr(label_server, "LOG_FILE", logs_dir / "log.txt")
+    label_server.app.logger.handlers.clear()
+    label_server.app.logger.addHandler(logging.NullHandler())
+    monkeypatch.setattr(label_server, "USER", "u")
+    monkeypatch.setattr(label_server, "PASSWORD", "p")
+
+    client = label_server.app.test_client()
+    resp = client.get(f"/spiel/{slug}/training", headers=_auth_header())
+    assert resp.status_code == 200
+    assert b"Label offers for" in resp.data
+
+
+def test_label_page_handles_root_dict(tmp_path, monkeypatch):
+    offers_dir = tmp_path / "data" / "offers"
+    labels_dir = tmp_path / "data" / "labels"
+    logs_dir = tmp_path / "data" / "logs"
+    for d in (offers_dir, labels_dir, logs_dir):
+        d.mkdir(parents=True)
+
+    slug = "game"
+    offers_file = offers_dir / f"{slug}.json"
+    offers_file.write_text(
+        json.dumps({"0": {"itemId": "1", "url": "u", "title": "t"}}),
+        "utf-8",
+    )
+
+    monkeypatch.setattr(label_server, "OFFERS_DIR", offers_dir)
+    monkeypatch.setattr(label_server, "LABEL_DIR", labels_dir)
+    monkeypatch.setattr(label_server, "LOG_DIR", logs_dir)
+    monkeypatch.setattr(label_server, "LOG_FILE", logs_dir / "log.txt")
+    label_server.app.logger.handlers.clear()
+    label_server.app.logger.addHandler(logging.NullHandler())
+    monkeypatch.setattr(label_server, "USER", "u")
+    monkeypatch.setattr(label_server, "PASSWORD", "p")
+
+    client = label_server.app.test_client()
+    resp = client.get(f"/spiel/{slug}/training", headers=_auth_header())
+    assert resp.status_code == 200
+    assert b"Label offers for" in resp.data


### PR DESCRIPTION
## Summary
- Guard against dictionaries when slicing eBay offers
- Handle legacy `searchResult.item` structure while normalising to a list
- Log label server errors to `data/logs/label_server.log`
- Accept root-level dict dumps when loading offers to prevent slicing errors
- Test legacy and root-dict JSON formats

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/train_relevance_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeaec76e4083218a7167aba0fc198a