### PR TITLE
Show eBay images and fix price indicator

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,5 @@
 
-// ui-version:2025-08-23-v12 – Menü-Overlay, Preisindikator ohne Graph, Suche & Cookie-Banner unten
+// ui-version:2025-08-23-v13 – Menü-Overlay, Preisindikator ohne Graph, Suche & Cookie-Banner unten
 (function(){
   // Menü
   var btn = document.getElementById('nav-toggle');
@@ -117,3 +117,25 @@ function click_offer(merchant, slug, price){
     gtag('event','click_offer',{merchant:merchant,slug:slug,price:price});
   }
 }
+
+window.renderPI = function(opts){
+  if(!opts) return;
+  var current=parseFloat(opts.current);
+  var avg=parseFloat(opts.avg7);
+  var badge=document.getElementById('pi-badge');
+  var marker=document.getElementById('pi-marker');
+  var curEl=document.getElementById('pi-current');
+  var avgEl=document.getElementById('pi-avg');
+  if(isNaN(current)||isNaN(avg)||!badge||!marker||!curEl||!avgEl) return;
+  curEl.textContent=current.toFixed(2)+'\u00a0€';
+  avgEl.textContent=avg.toFixed(2)+'\u00a0€';
+  var diff=(current-avg)/avg*100;
+  var left=Math.max(0,Math.min(100,50+diff));
+  marker.style.left=left+'%';
+  var cls='orange';
+  if(diff<=-5){cls='green';}
+  else if(diff>=5){cls='red';}
+  badge.classList.add(cls);
+  marker.classList.add(cls);
+  badge.textContent=(diff>0?'+':'')+diff.toFixed(0)+'%';
+};

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-/* ui-version:2025-08-23-v12 – Preisindikator Fixes */
+/* ui-version:2025-08-23-v13 – Preisindikator Fixes */
 :root{
   --color-primary:#ff7f11;
   --color-secondary:#ff9f1c;

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- ui-version:2025-08-23-v12 -->
+<!-- ui-version:2025-08-23-v13 -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
@@ -7,8 +7,8 @@
   <title>{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar</title>
   {% if meta_description %}<meta name="description" content="{{ meta_description|e }}">{% endif %}
   <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-23-v12" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v12">
+  <link rel="preload" href="/styles.css?v=2025-08-23-v13" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v13">
   {% if canonical %}<link rel="canonical" href="{{ canonical }}">{% endif %}
   <meta property="og:type" content="website">
   <meta property="og:title" content="{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar">
@@ -79,7 +79,7 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-23-v12" defer></script>
+  <script src="/main.js?v=2025-08-23-v13" defer></script>
 </body>
 </html>
 

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -31,6 +31,7 @@
   {% if best %}
   {% set diff = ((min_price - avg7) / avg7 * 100) if (min_price and avg7) else None %}
   <section class="best-price" aria-label="Bestpreis">
+    {% if best.image_url %}<img class="offer-img" src="{{ best.image_url }}" alt="" loading="lazy">{% endif %}
     <div class="bp-main">
       <span class="bp-price">{{ '%.2f'|format(best.total_eur or best.price_eur) }}&nbsp;€</span>
       {% if best.shop %}<span class="bp-shop">{{ best.shop }}</span>{% endif %}


### PR DESCRIPTION
## Summary
- Display offer image from eBay in the "Jetzt zum Deal" best-price tile
- Implement client-side price indicator rendering and bump UI asset versions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6a7b0c88321a0348645f8a7e2d9