### PR TITLE
Fix price indicator rendering and show full offer images

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -149,7 +149,7 @@ a:hover{text-decoration:underline}
 .badge{position:absolute;top:10px;right:10px;background:var(--color-secondary);color:#052e16;font-weight:800;font-size:.75rem;border-radius:999px;padding:4px 8px}
 .badge-grey{background:var(--badge);color:var(--badge-text);right:auto;left:10px}
 .badge-cheap{background:var(--good);color:#fff;font-weight:700;font-size:.75rem;border-radius:999px;padding:2px 6px;margin-left:4px}
-.offer-img{width:100%;aspect-ratio:4/3;object-fit:cover;border-radius:10px;border:1px solid var(--border);margin-bottom:10px}
+.offer-img{width:100%;aspect-ratio:4/3;object-fit:contain;background:#fff;border-radius:10px;border:1px solid var(--border);margin-bottom:10px}
 .offer-title{
   margin:0 0 8px;font-size:1rem;
   display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;min-height:2.6em;line-height:1.3;

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -207,7 +207,7 @@
       const data = hist.map(r=>r.min);
       new Chart(ctx,{type:'line',data:{labels:labels,datasets:[{label:'Preis',data:data,borderColor:'#3e95cd',fill:false}]},options:{plugins:{legend:{display:false}},scales:{y:{ticks:{callback:(v)=>v+' €'}}}}});
     }
-    {% if min_price and avg7 %}
+    {% if min_price is not none and avg7 is not none %}
     if (typeof window.renderPI === 'function'){
       window.renderPI({current: {{ '%.2f'|format(min_price) }}, avg7: {{ '%.2f'|format(avg7) }}} );
     }


### PR DESCRIPTION
## Summary
- Ensure price indicator renders when both `min_price` and `avg7` are present
- Prevent eBay offer images from being cropped by displaying entire image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedf169a088321b71747d9e0987eec