### PR TITLE
Restore desktop price table and highlight best offer

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -142,6 +142,11 @@ a:hover{text-decoration:underline}
 /* NEWER offer layout (Grid/Card) with responsive table fallback */
 .offer-grid{display:grid;grid-template-columns:1fr;gap:12px}
 @media (min-width:640px){ .offer-grid{grid-template-columns:repeat(2,minmax(0,1fr))} }
+.offers-table{width:100%;border-collapse:collapse;margin-top:12px;display:none}
+.offers-table th,.offers-table td{padding:8px;text-align:left;border-bottom:1px solid var(--border)}
+.offers-table tr.best{background:color-mix(in srgb,var(--good) 16%, white)}
+.offers-table tr.best .price{color:var(--good);font-weight:700}
+@media (min-width:720px){ .offer-grid{display:none} .offers-table{display:table} }
 .offer-card{
   position:relative;background:var(--card);border:1px solid var(--border);border-radius:14px;padding:14px;box-shadow:0 2px 8px rgba(0,0,0,.04);
   display:flex;flex-direction:column;min-height:320px;

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -75,6 +75,24 @@
         </article>
       {% endfor %}
     </div>
+    <table class="offers-table">
+      <thead>
+        <tr><th>Angebot</th><th>Preis</th><th>Zustand</th><th>Shop</th><th></th></tr>
+      </thead>
+      <tbody>
+        {% for o in offers %}
+          {% set extra = loop.index > 4 %}
+          {% set sep = '?' if '?' not in o.url else '&' %}
+          <tr class="offer-row{% if loop.first %} best{% endif %}{% if extra %} extra{% endif %}" {% if extra %}style="display:none"{% endif %} data-offer>
+            <td class="offer-title"><a href="{{ o.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a>{% if loop.first %}<span class="badge-cheap">Bestpreis</span>{% endif %}</td>
+            <td class="price">{% if o.total_eur is number %}{{ '%.2f'|format(o.total_eur) }}&nbsp;€{% else %}–{% endif %}</td>
+            <td class="condition">{% if o.condition %}{{ o.condition }}{% endif %}</td>
+            <td class="seller">{% if o.shop %}{{ o.shop }}{% endif %}</td>
+            <td class="action"><a class="btn btn-secondary offer-link" href="{{ o.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" onclick="click_offer('{{ o.shop }}','{{ game.slug }}','{{ o.total_eur or o.price_eur }}')" target="_blank" rel="nofollow sponsored noopener">Zum Angebot</a></td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
     {% if offers|length > 4 %}
     <div class="cta-row"><button id="moreOffersBtn" class="btn btn-link">Weitere Angebote anzeigen</button></div>
     {% endif %}
@@ -215,7 +233,13 @@
     var moreBtn=document.getElementById('moreOffersBtn');
     if(moreBtn){
       moreBtn.addEventListener('click',function(){
-        document.querySelectorAll('.offer-card.extra').forEach(function(el){ el.style.display='flex'; });
+        document.querySelectorAll('.offer-card.extra, .offer-row.extra').forEach(function(el){
+          if(el.tagName === 'TR'){
+            el.style.display='table-row';
+          } else {
+            el.style.display='flex';
+          }
+        });
         moreBtn.remove();
       });
     }


### PR DESCRIPTION
## Summary
- Switch desktop price comparison from tiles to an HTML table
- Highlight the best offer with a badge and row styling
- Ensure "Weitere Angebote anzeigen" reveals hidden table rows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee3c95b408321b2c92b5cebf06488