### PR TITLE
Add training overview page and polish labeling UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ kleinen Trainingsworkflow:
      ```bash
      python scripts/label_server.py
      ```
-   - Rufe im Browser `http://localhost:8000/spiel/<slug>/training` auf und markiere die
-     angezeigten Angebote als „relevant“ oder „nicht relevant“. Die Seite zeigt
-     bis zu 100 unlabeled Treffer inklusive Bild und Kurzbeschreibung; bereits
+   - Rufe im Browser `http://localhost:8000/training` auf und wähle ein Spiel.
+     Auf der jeweiligen Spielseite kannst du die angezeigten Angebote als
+     „relevant“ oder „nicht relevant“ markieren. Die Seite zeigt bis zu 100
+     unlabeled Treffer inklusive Bild und Kurzbeschreibung; bereits
      bewertete Angebote werden ausgeblendet. Die Labels
 
    werden in `data/labels/<slug>.json` gespeichert. Fehler beim Einlesen

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /spiel/*/training
+Disallow: /training

--- a/tests/test_label_server.py
+++ b/tests/test_label_server.py
@@ -15,6 +15,33 @@ def _auth_header(user="u", password="p"):
     return {"Authorization": f"Basic {token}"}
 
 
+def test_training_index_lists_games(tmp_path, monkeypatch):
+    offers_dir = tmp_path / "data" / "offers"
+    labels_dir = tmp_path / "data" / "labels"
+    logs_dir = tmp_path / "data" / "logs"
+    for d in (offers_dir, labels_dir, logs_dir):
+        d.mkdir(parents=True)
+
+    (offers_dir / "g1.json").write_text(json.dumps([]), "utf-8")
+    (offers_dir / "g2.json").write_text(json.dumps([]), "utf-8")
+
+    monkeypatch.setattr(label_server, "OFFERS_DIR", offers_dir)
+    monkeypatch.setattr(label_server, "LABEL_DIR", labels_dir)
+    monkeypatch.setattr(label_server, "LOG_DIR", logs_dir)
+    monkeypatch.setattr(label_server, "LOG_FILE", logs_dir / "log.txt")
+    label_server.app.logger.handlers.clear()
+    label_server.app.logger.addHandler(logging.NullHandler())
+    monkeypatch.setattr(label_server, "USER", "u")
+    monkeypatch.setattr(label_server, "PASSWORD", "p")
+
+    client = label_server.app.test_client()
+    resp = client.get("/training", headers=_auth_header())
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "/spiel/g1/training" in body
+    assert "/spiel/g2/training" in body
+
+
 def test_label_page_handles_searchresult_dict(tmp_path, monkeypatch):
     offers_dir = tmp_path / "data" / "offers"
     labels_dir = tmp_path / "data" / "labels"


### PR DESCRIPTION
## Summary
- add `/training` overview page to navigate to each game's labeling view
- refactor label server for cleaner offer loading and add simple styling
- document training workflow update and disallow new index in `robots.txt`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af2fa16f4483219971cfae6d404da4