### PR TITLE
Default eBay category to board games

### DIFF
--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -240,7 +240,10 @@ def fetch_for_game(game: Dict[str, Any], max_keep: int = 100) -> List[Dict[str, 
     slug = game.get("slug")
     if not slug:
         return []
-    category_id = str(game.get("ebay_category_id") or "").strip() or None
+    category_id = game.get("ebay_category_id")
+    category_id = str(category_id).strip() if category_id is not None else ""
+    if not category_id:
+        category_id = "180349"
     price_filter = game.get("price_filter") or {}
     aspect_filters = game.get("aspect_filters") or None
     exclude_terms = [t.lower() for t in game.get("exclude_keywords", []) if isinstance(t, str)]

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -83,6 +83,16 @@ def test_fetch_for_game_passes_min_price():
         _, kwargs = mock_search.call_args
         assert kwargs["min_price"] == 5
 
+
+def test_fetch_for_game_uses_default_category_id():
+    mod = load_module()
+    game = {"slug": "catan", "search_terms": ["Catan"]}
+    with patch("scripts.fetch_offers_ebay_enhanced.search_once") as mock_search:
+        mock_search.return_value = []
+        mod.fetch_for_game(game)
+        _, kwargs = mock_search.call_args
+        assert kwargs["category_id"] == "180349"
+
 def test_fetch_for_game_passes_aspect_filters():
     mod = load_module()
     game = {


### PR DESCRIPTION
## Summary
- Default `fetch_for_game` to use eBay board game category `180349` when no override is supplied.
- Ensure API requests include `categoryIds:180349` so only board-game offers are retrieved.
- Add regression test for the default category handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3f55e1b608321bc829ca22425c7a1