### PR TITLE
Ignore label server logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 .env
 data/offers/*.json
+data/logs/


### PR DESCRIPTION
## Summary
- ignore label server logs by adding `data/logs/` to `.gitignore`
- ensure any existing `data/logs/label_server.log` is removed from version control

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3f6680710832199c36c59a07f0027