### PR TITLE
Improve labeling feedback on training page

### DIFF
--- a/scripts/label_server.py
+++ b/scripts/label_server.py
@@ -192,11 +192,19 @@ function render(){
   container.innerHTML='';
   offers.forEach(o=>{
     const id=o.itemId || o.id || o.url;
+    if (labels[id] !== undefined){
+      return; // bereits gelabelt – ausblenden
+    }
     const div=document.createElement('div');
     div.className='offer';
     const img = o.image_url ? `<img src="${o.image_url}" alt="">` : '';
-    const desc = o.description ? `<p>${o.description}</p>` : '';
-    div.innerHTML = `${img}<p><a href="${o.url}" target="_blank">${o.title||id}</a> – ${o.total_eur||o.price_eur||''} €</p>${desc}`;
+    div.innerHTML = `${img}<p><a href="${o.url}" target="_blank">${o.title||id}</a> – ${o.total_eur||o.price_eur||''} €</p>`;
+    const descText = o.description || o.subtitle;
+    if (descText){
+      const p=document.createElement('p');
+      p.textContent=descText;
+      div.appendChild(p);
+    }
     const rel=document.createElement('button');
     rel.textContent='relevant';
     rel.onclick=()=>{labels[id]=true; sendLabel(id,true); render();};

--- a/scripts/train_relevance_model.py
+++ b/scripts/train_relevance_model.py
@@ -31,9 +31,23 @@ def load_dataset():
         offers_file = OFFERS_DIR / f"{slug}.json"
         if not offers_file.exists():
             continue
-        offers = json.loads(offers_file.read_text("utf-8"))
+        data = json.loads(offers_file.read_text("utf-8"))
         label_map = json.loads(label_file.read_text("utf-8"))
+
+        # normalise structure similar to label_server._load_offers
+        if isinstance(data, dict):
+            offers = data.get("offers") or data.get("searchResult", {}).get("item") or data
+            if isinstance(offers, dict):
+                offers = list(offers.values())
+        else:
+            offers = data
+
+        if not isinstance(offers, list):
+            offers = []
+
         for offer in offers:
+            if not isinstance(offer, dict):
+                continue
             item_id = str(offer.get("itemId") or offer.get("id") or offer.get("url") or "")
             if not item_id or item_id not in label_map:
                 continue

--- a/tests/test_label_server.py
+++ b/tests/test_label_server.py
@@ -135,6 +135,73 @@ def test_label_page_hides_already_labeled(tmp_path, monkeypatch):
     assert "u2" in body
 
 
+def test_label_page_shows_description(tmp_path, monkeypatch):
+    offers_dir = tmp_path / "data" / "offers"
+    labels_dir = tmp_path / "data" / "labels"
+    logs_dir = tmp_path / "data" / "logs"
+    for d in (offers_dir, labels_dir, logs_dir):
+        d.mkdir(parents=True)
+
+    slug = "game"
+    offers_file = offers_dir / f"{slug}.json"
+    offers_file.write_text(
+        json.dumps([{ "itemId": "1", "url": "u", "title": "t", "description": "foo bar" }]),
+        "utf-8",
+    )
+
+    monkeypatch.setattr(label_server, "OFFERS_DIR", offers_dir)
+    monkeypatch.setattr(label_server, "LABEL_DIR", labels_dir)
+    monkeypatch.setattr(label_server, "LOG_DIR", logs_dir)
+    monkeypatch.setattr(label_server, "LOG_FILE", logs_dir / "log.txt")
+    label_server.app.logger.handlers.clear()
+    label_server.app.logger.addHandler(logging.NullHandler())
+    monkeypatch.setattr(label_server, "USER", "u")
+    monkeypatch.setattr(label_server, "PASSWORD", "p")
+
+    client = label_server.app.test_client()
+    resp = client.get(f"/spiel/{slug}/training", headers=_auth_header())
+    assert resp.status_code == 200
+    assert "foo bar" in resp.data.decode()
+
+
+def test_label_page_escapes_description(tmp_path, monkeypatch):
+    offers_dir = tmp_path / "data" / "offers"
+    labels_dir = tmp_path / "data" / "labels"
+    logs_dir = tmp_path / "data" / "logs"
+    for d in (offers_dir, labels_dir, logs_dir):
+        d.mkdir(parents=True)
+
+    slug = "game"
+    offers_file = offers_dir / f"{slug}.json"
+    offers_file.write_text(
+        json.dumps([
+            {
+                "itemId": "1",
+                "url": "u",
+                "title": "t",
+                "description": "<b>bold</b>"
+            }
+        ]),
+        "utf-8",
+    )
+
+    monkeypatch.setattr(label_server, "OFFERS_DIR", offers_dir)
+    monkeypatch.setattr(label_server, "LABEL_DIR", labels_dir)
+    monkeypatch.setattr(label_server, "LOG_DIR", logs_dir)
+    monkeypatch.setattr(label_server, "LOG_FILE", logs_dir / "log.txt")
+    label_server.app.logger.handlers.clear()
+    label_server.app.logger.addHandler(logging.NullHandler())
+    monkeypatch.setattr(label_server, "USER", "u")
+    monkeypatch.setattr(label_server, "PASSWORD", "p")
+
+    client = label_server.app.test_client()
+    resp = client.get(f"/spiel/{slug}/training", headers=_auth_header())
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "<b>bold</b>" not in body
+    assert "\\u003cb\\u003ebold\\u003c/b\\u003e" in body
+
+
 def test_label_page_hides_negative_labels(tmp_path, monkeypatch):
     offers_dir = tmp_path / "data" / "offers"
     labels_dir = tmp_path / "data" / "labels"

--- a/tests/test_train_relevance_model.py
+++ b/tests/test_train_relevance_model.py
@@ -1,0 +1,27 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import train_relevance_model
+
+
+def test_load_dataset_skips_non_dict(tmp_path, monkeypatch):
+    offers_dir = tmp_path / "data" / "offers"
+    labels_dir = tmp_path / "data" / "labels"
+    offers_dir.mkdir(parents=True)
+    labels_dir.mkdir(parents=True)
+
+    slug = "game"
+    (offers_dir / f"{slug}.json").write_text(
+        json.dumps(["oops", {"itemId": "1", "title": "foo"}]), "utf-8"
+    )
+    (labels_dir / f"{slug}.json").write_text(json.dumps({"1": True}), "utf-8")
+
+    monkeypatch.setattr(train_relevance_model, "OFFERS_DIR", offers_dir)
+    monkeypatch.setattr(train_relevance_model, "LABEL_DIR", labels_dir)
+
+    texts, labels = train_relevance_model.load_dataset()
+    assert len(texts) == 1
+    assert labels == [1]


### PR DESCRIPTION
## Summary
- Hide offers on the training page once they are labeled
- Show available offer descriptions (or subtitles) during labeling and escape HTML
- Add regression tests for description rendering and escaping
- Normalize offer JSON and skip malformed entries when training relevance model
- Cover dataset parsing edge cases in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3f4b169ac83218177a8bc73ea78a6