### PR TITLE
Log YAML field issues instead of displaying on game pages

### DIFF
--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -71,10 +71,6 @@
     <p class="pi-note">Basis: Tages-Bestpreis inkl. Versand vs. Ø der letzten 7 Tage.</p>
   </section>
 
-  {% if missing_fields %}
-  <p class="muted">⚠️ Fehlende YAML-Werte: {{ missing_fields|join(', ') }}</p>
-  {% endif %}
-
   <section class="offers" id="angebote">
     <div class="offers-head">
       <h2 class="h2">Preisvergleich</h2>


### PR DESCRIPTION
## Summary
- log missing YAML fields to `data/logs/build.log` during build
- stop rendering missing field warnings on game pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bab56cf0ac8321ad6e1c93ace352be