### PR TITLE
Bestpreis-Box verkleinern und Preisvergleich-Tabelle aufhübschen

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-/* ui-version:2025-08-23-v13 – Preisindikator Fixes */
+/* ui-version:2025-08-23-v14 – Kompaktere Bestpreis-Box & hübschere Tabelle */
 :root{
   --color-primary:#ff7f11;
   --color-secondary:#ff9f1c;
@@ -82,6 +82,12 @@ a:hover{text-decoration:underline}
 .bp-indicator{margin:0;font-size:.95rem}
 .bp-badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:4px}
 
+@media (min-width:720px){
+  .best-price{max-width:420px;margin:14px auto}
+  .bp-price{font-size:1.4rem}
+  .bp-img{max-width:260px;margin-left:auto;margin-right:auto}
+}
+
 /* Price Indicator */
 .price-indicator{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:14px 0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:var(--pi-fg)}
 .pi-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
@@ -138,8 +144,28 @@ a:hover{text-decoration:underline}
 /* NEWER offer layout (Grid/Card) with responsive table fallback */
 .offer-grid{display:grid;grid-template-columns:1fr;gap:12px}
 @media (min-width:640px){ .offer-grid{grid-template-columns:repeat(2,minmax(0,1fr))} }
-.offers-table{width:100%;border-collapse:collapse;margin-top:12px;display:none}
-.offers-table th,.offers-table td{padding:8px;text-align:left;border-bottom:1px solid var(--border)}
+.offers-table{
+  width:100%;
+  border-collapse:separate;
+  border-spacing:0;
+  margin-top:12px;
+  display:none;
+  border:1px solid var(--border);
+  border-radius:14px;
+  overflow:hidden;
+}
+.offers-table th{
+  background:var(--panel);
+  font-weight:600;
+}
+.offers-table th,.offers-table td{
+  padding:10px;
+  text-align:left;
+  border-bottom:1px solid var(--border);
+}
+.offers-table tbody tr:nth-child(even){background:#f8fafc}
+.offers-table tbody tr:hover{background:#f1f5f9}
+.offers-table tbody tr:last-child td{border-bottom:none}
 .offers-table tr.best{background:color-mix(in srgb,var(--good) 16%, white)}
 .offers-table tr.best .price{color:var(--good);font-weight:700}
 @media (min-width:720px){ .offer-grid{display:none} .offers-table{display:table} }


### PR DESCRIPTION
## Summary
- Verkleinere und zentriere die Bestpreis-Box für klarere Desktop-Ansicht
- Style die Preisvergleichstabelle mit Rahmen, Abständen und Hover-Effekten

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab5c3a1048321bf70a89522e59873