### PR TITLE
Filter non-board-game eBay results

### DIFF
--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -8,6 +8,7 @@
 - Supports per-game YAML `search_terms` (DE+EN), tries multiple queries
 - Excludes accessory items and private sellers, keeps only new-condition listings
 - Robust price detection (price / priceRange.min / currentBidPrice), EUR only
+- Filters results to the requested eBay category (default: board games)
 """
 
 import os, json, time, datetime as dt
@@ -267,6 +268,9 @@ def fetch_for_game(game: Dict[str, Any], max_keep: int = 100) -> List[Dict[str, 
         for it in items:
             iid = it.get("itemId")
             if not iid or iid in seen:
+                continue
+            cat_id_item = str(it.get("categoryId") or "")
+            if category_id and cat_id_item and cat_id_item != category_id:
                 continue
             price = pick_price_eur(it)
             if price is None or price <= 0:

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -93,6 +93,25 @@ def test_fetch_for_game_uses_default_category_id():
         _, kwargs = mock_search.call_args
         assert kwargs["category_id"] == "180349"
 
+
+def test_fetch_for_game_filters_wrong_category():
+    mod = load_module()
+    game = {"slug": "catan", "search_terms": ["Catan"], "ebay_category_id": "180349"}
+    with patch("scripts.fetch_offers_ebay_enhanced.search_once") as mock_search:
+        mock_search.return_value = [
+            {
+                "itemId": "1",
+                "title": "Catan",
+                "categoryId": "123",
+                "price": {"currency": "EUR", "value": "10"},
+                "conditionId": "1000",
+                "seller": {"username": "other", "accountType": "BUSINESS"},
+                "itemWebUrl": "http://example.com",
+            }
+        ]
+        offers = mod.fetch_for_game(game)
+        assert offers == []
+
 def test_fetch_for_game_passes_aspect_filters():
     mod = load_module()
     game = {


### PR DESCRIPTION
## Summary
- Ensure the eBay offer fetcher drops items that are not in the requested category (default: board games)
- Document category filtering behavior
- Test that items with mismatched categories are ignored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab871df848321a0ea9028b7810fc0