### PR TITLE
Improve price chart layout and mobile scrolling

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -194,6 +194,10 @@ a:hover{text-decoration:underline}
 .price-history .avg-price{font-weight:700;font-size:1.1rem;margin:0}
 .price-history canvas{max-width:100%}
 
+@media (min-width:720px){
+  .price-history .price-chart{max-width:600px;margin-left:auto;margin-right:auto}
+}
+
 .faq details{border:1px solid var(--border);border-radius:10px;margin:8px 0;background:#f8fafc}
 .faq summary{cursor:pointer;padding:12px 14px;font-weight:700;min-height:44px;display:flex;align-items:center}
 .faq .answer{padding:0 14px 12px}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -242,28 +242,21 @@
     var sticky=document.getElementById('stickyBuyBar');
     var dealBtn=document.getElementById('dealBtn');
     if(sticky && dealBtn && window.matchMedia('(max-width:719px)').matches){
-      var placeholder=document.createElement('div');
-      placeholder.style.height='0px';
-      dealBtn.parentNode.insertBefore(placeholder, dealBtn);
-      var btnHeight=dealBtn.offsetHeight;
+      var stickyBtn=dealBtn.cloneNode(true);
+      stickyBtn.id='stickyDealBtn';
+      sticky.appendChild(stickyBtn);
       var observer=new IntersectionObserver(function(entries){
         entries.forEach(function(entry){
-          if(entry.isIntersecting){
-            placeholder.style.height='0px';
-            if(sticky.contains(dealBtn)){
-              placeholder.parentNode.insertBefore(dealBtn, placeholder.nextSibling);
-            }
-            sticky.classList.remove('show');
-          } else {
-            placeholder.style.height=btnHeight+'px';
-            if(!sticky.contains(dealBtn)){
-              sticky.appendChild(dealBtn);
-            }
-            sticky.classList.add('show');
-          }
+          sticky.classList.toggle('show', !entry.isIntersecting);
         });
       });
-      observer.observe(placeholder);
+      observer.observe(dealBtn);
+    }
+
+    var priceHistory=document.querySelector('.price-history');
+    var priceIndicator=document.querySelector('.price-indicator');
+    if(priceHistory && priceIndicator && window.matchMedia('(max-width:719px)').matches){
+      priceIndicator.insertAdjacentElement('afterend', priceHistory);
     }
   });
   </script>


### PR DESCRIPTION
## Summary
- Limit price chart width on desktop for a clearer layout
- Move price history directly below price indicator on mobile
- Replace sticky buy button logic to avoid scroll jumping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bab9217bf48321ba12e05da2721b0c