### PR TITLE
Center price table for cleaner layout

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -142,12 +142,12 @@ a:hover{text-decoration:underline}
 .offers-head{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
 
 /* Responsive price table */
-.offers{width:min(1100px,92vw);margin:1.2rem auto 2rem}
+.offers{width:min(800px,92vw);margin:1.2rem auto 2rem}
 .price-table{
-  width:100%;
+  width:min(800px,100%);
   border-collapse:separate;
   border-spacing:0;
-  margin-top:12px;
+  margin:12px auto;
   background:var(--card);
   border:1px solid var(--border);
   border-radius:14px;


### PR DESCRIPTION
## Summary
- Limit width of price comparison section and table
- Center price table for a more balanced layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc64a570e08321827b9cc014a688e0