### PR TITLE
feat: allow default eBay category via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ py scripts\build.py
 
 In `config/filters.yaml` kannst du den Marktplatz und die Währung anpassen
 (`marketplace_id`, `price_currency`). Standard ist `EBAY_DE` mit `EUR` und
-`item_location_countries: [DE]` für Angebote aus Deutschland. Pro Spiel lässt
- sich in `content/games/<slug>.yaml` über `search_terms` festlegen, welche
- Schlüsselwörter an die eBay‑API übergeben werden. Ein optionales
+`item_location_countries: [DE]` für Angebote aus Deutschland. Über
+`default_ebay_category_id` legst du fest, welche eBay-Kategorie für die Suche
+verwendet wird (z. B. `180349` für Brettspiele). Pro Spiel lässt
+sich in `content/games/<slug>.yaml` über `search_terms` festlegen, welche
+Schlüsselwörter an die eBay‑API übergeben werden. Ein optionales
 `price_filter: {min: 20}` setzt einen Mindestpreis.
 
 **Amazon Affiliate**

--- a/config/filters.yaml
+++ b/config/filters.yaml
@@ -40,3 +40,6 @@ item_location_countries:
 # eBay marketplace and currency settings
 marketplace_id: EBAY_DE
 price_currency: EUR
+
+# Default eBay category for searches (board games)
+default_ebay_category_id: 180349

--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -108,6 +108,11 @@ ITEM_LOCATION_COUNTRIES = [
 MARKETPLACE_ID = FILTER_CFG.get("marketplace_id", "EBAY_DE")
 PRICE_CURRENCY = FILTER_CFG.get("price_currency", "EUR")
 
+# Default eBay category ID used when games do not specify one
+DEFAULT_CATEGORY_ID = str(
+    FILTER_CFG.get("default_ebay_category_id", "180349")
+).strip()
+
 HEADERS = build_headers()
 
 
@@ -244,7 +249,7 @@ def fetch_for_game(game: Dict[str, Any], max_keep: int = 100) -> List[Dict[str, 
     category_id = game.get("ebay_category_id")
     category_id = str(category_id).strip() if category_id is not None else ""
     if not category_id:
-        category_id = "180349"
+        category_id = DEFAULT_CATEGORY_ID
     price_filter = game.get("price_filter") or {}
     aspect_filters = game.get("aspect_filters") or None
     exclude_terms = [t.lower() for t in game.get("exclude_keywords", []) if isinstance(t, str)]

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -86,12 +86,13 @@ def test_fetch_for_game_passes_min_price():
 
 def test_fetch_for_game_uses_default_category_id():
     mod = load_module()
+    mod.DEFAULT_CATEGORY_ID = "99999"
     game = {"slug": "catan", "search_terms": ["Catan"]}
     with patch("scripts.fetch_offers_ebay_enhanced.search_once") as mock_search:
         mock_search.return_value = []
         mod.fetch_for_game(game)
         _, kwargs = mock_search.call_args
-        assert kwargs["category_id"] == "180349"
+        assert kwargs["category_id"] == "99999"
 
 
 def test_fetch_for_game_filters_wrong_category():


### PR DESCRIPTION
## Summary
- add `default_ebay_category_id` to filter config so searches can be restricted to a category
- use configured category in eBay fetcher when games don't specify one
- document new option and adjust tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc64ef872883218afbc2087f109913