### PR TITLE
feat: redesign price indicator

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -118,24 +118,3 @@ function click_offer(merchant, slug, price){
   }
 }
 
-window.renderPI = function(opts){
-  if(!opts) return;
-  var current=parseFloat(opts.current);
-  var avg=parseFloat(opts.avg7);
-  var badge=document.getElementById('pi-badge');
-  var marker=document.getElementById('pi-marker');
-  var curEl=document.getElementById('pi-current');
-  var avgEl=document.getElementById('pi-avg');
-  if(isNaN(current)||isNaN(avg)||!badge||!marker||!curEl||!avgEl) return;
-  curEl.textContent=current.toFixed(2)+'\u00a0€';
-  avgEl.textContent=avg.toFixed(2)+'\u00a0€';
-  var diff=(current-avg)/avg*100;
-  var left=Math.max(0,Math.min(100,50+diff));
-  marker.style.left=left+'%';
-  var cls='orange';
-  if(diff<=-5){cls='green';}
-  else if(diff>=5){cls='red';}
-  badge.classList.add(cls);
-  marker.classList.add(cls);
-  badge.textContent=(diff>0?'+':'')+diff.toFixed(0)+'%';
-};

--- a/public/styles.css
+++ b/public/styles.css
@@ -16,13 +16,27 @@
   --shadow:0 8px 24px rgba(0,0,0,.08);
   --badge:#334155;
   --badge-text:#e2e8f0;
-  --pi-green:#0a8f55;
-  --pi-orange:#b26a00;
-  --pi-red:#b00020;
-  --pi-bg:#f6f7f9;
-  --pi-fg:#0d1117;
-  --pi-muted:#6b7280;
   --pi-ring:rgba(0,0,0,.08);
+  --bpr-bg:#0b0c0f;
+  --bpr-card:#11131a;
+  --bpr-text:#e9ecf1;
+  --bpr-muted:#a3adbd;
+  --bpr-border:#222633;
+  --bpr-good:#22c55e;
+  --bpr-ok:#eab308;
+  --bpr-high:#ef4444;
+  --bpr-link:#60a5fa;
+}
+
+@media (prefers-color-scheme:light){
+  :root{
+    --bpr-bg:#ffffff;
+    --bpr-card:#f8fafc;
+    --bpr-text:#0f172a;
+    --bpr-muted:#475569;
+    --bpr-border:#e2e8f0;
+    --bpr-link:#2563eb;
+  }
 }
 
 *{box-sizing:border-box}
@@ -88,27 +102,44 @@ a:hover{text-decoration:underline}
   .bp-img{max-width:260px;margin-left:auto;margin-right:auto}
 }
 
-/* Price Indicator */
-.price-indicator{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:14px 0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:var(--pi-fg)}
-.pi-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
-.pi-title{font-weight:600}
-.pi-badge{font-weight:700;padding:4px 8px;border-radius:999px;background:var(--pi-bg)}
-.pi-badge.green{background:#dcefe7;background:color-mix(in srgb,var(--pi-green) 14%,white);color:var(--pi-green)}
-.pi-badge.orange{background:#f4eadb;background:color-mix(in srgb,var(--pi-orange) 14%,white);color:var(--pi-orange)}
-.pi-badge.red{background:#f4dbe0;background:color-mix(in srgb,var(--pi-red) 14%,white);color:var(--pi-red)}
+/* Layout for Bestpreis + Preisindikator */
+.hero-offers{display:flex;flex-direction:column;gap:14px;margin:14px 0}
+@media (min-width:880px){.hero-offers{flex-direction:row}.hero-offers>section{flex:1;margin:0}}
 
-.pi-bar{position:relative;height:10px;border-radius:999px;overflow:hidden;margin:8px 0 6px;box-shadow:inset 0 0 0 1px var(--pi-ring);background:linear-gradient(to right,#d2eae0 0%,#d2eae0 33.33%,#f1e4d1 33.33%,#f1e4d1 66.66%,#f0d1d7 66.66%,#f0d1d7 100%);background:linear-gradient(to right,color-mix(in srgb,var(--pi-green) 18%,white) 0%,color-mix(in srgb,var(--pi-green) 18%,white) 33.33%,color-mix(in srgb,var(--pi-orange) 18%,white) 33.33%,color-mix(in srgb,var(--pi-orange) 18%,white) 66.66%,color-mix(in srgb,var(--pi-red) 18%,white) 66.66%,color-mix(in srgb,var(--pi-red) 18%,white) 100%)}
-.pi-marker{position:absolute;top:-4px;width:2px;height:18px;background:#111;left:50%;transform:translateX(-1px)}
-.pi-marker.green{background:var(--pi-green)}
-.pi-marker.orange{background:var(--pi-orange)}
-.pi-marker.red{background:var(--pi-red)}
-
-
-.pi-stats{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px 16px;margin:6px 0}
-.pi-stats dt{font-weight:600;color:var(--pi-muted)}
-.pi-stats dd{margin:0}
-.pi-note{margin:6px 0 0;color:var(--pi-muted);font-size:12px}
-@media (max-width:420px){ .pi-stats{grid-template-columns:1fr} }
+/* Neuer Preisindikator */
+.bpr-price-indicator{color:var(--bpr-text);background:transparent}
+.bpr-card{border:1px solid var(--bpr-border);background:var(--bpr-card);border-radius:16px;padding:clamp(16px,2.5vw,24px);box-shadow:0 6px 24px rgba(0,0,0,.12)}
+.bpr-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px}
+.bpr-title{font-size:clamp(18px,2.4vw,22px);margin:0;letter-spacing:.2px}
+.bpr-pill{display:inline-flex;gap:.5rem;align-items:center;border:1px solid var(--bpr-border);border-radius:999px;padding:6px 10px;font-weight:600;font-size:.9rem;background:rgba(255,255,255,.03)}
+.bpr-pill__dot{width:10px;height:10px;border-radius:999px;background:var(--bpr-ok);box-shadow:0 0 0 4px rgba(0,0,0,.05) inset}
+.bpr-pill__label{color:var(--bpr-muted)}
+.bpr-grid{display:grid;grid-template-columns:1fr;gap:18px}
+@media (min-width:880px){.bpr-grid{grid-template-columns:1.2fr .8fr;gap:24px}}
+.bpr-price{display:grid;grid-template-columns:auto 1fr;grid-template-areas:'label value' 'delta delta';align-items:end;column-gap:12px}
+.bpr-price__label{grid-area:label;color:var(--bpr-muted);font-weight:600}
+.bpr-price__value{grid-area:value;font-size:clamp(28px,5vw,40px);font-weight:800;letter-spacing:.2px}
+.bpr-price__delta{grid-area:delta;color:var(--bpr-muted);font-weight:600;margin-top:4px}
+.bpr-metrics{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:14px}
+.bpr-metric{border:1px dashed var(--bpr-border);border-radius:12px;padding:10px 12px}
+.bpr-metric__label{color:var(--bpr-muted);font-size:.82rem}
+.bpr-metric__value{font-weight:700;margin-top:2px}
+.bpr-gauge{position:relative;margin-top:14px;padding-top:16px}
+.bpr-gauge__track{height:10px;background:linear-gradient(90deg,var(--bpr-good) 0 33%,var(--bpr-ok) 33% 66%,var(--bpr-high) 66% 100%);border-radius:999px;opacity:.85}
+.bpr-gauge__fill{position:absolute;left:0;top:16px;height:10px;width:0;background:rgba(255,255,255,.2);border-radius:999px;pointer-events:none}
+.bpr-gauge__marker{position:absolute;top:8px;transform:translate(-50%,-50%);background:var(--bpr-card);border:1px solid var(--bpr-border);padding:2px 6px;border-radius:8px;font-size:.75rem;white-space:nowrap}
+.bpr-gauge__legend{display:flex;justify-content:space-between;margin-top:8px;font-size:.8rem;color:var(--bpr-muted)}
+.bpr-side{display:grid;gap:14px;align-content:start}
+.bpr-spark{display:grid;gap:8px}
+.bpr-spark svg{width:100%;height:120px;background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,0));border:1px solid var(--bpr-border);border-radius:12px;padding:8px}
+.bpr-spark__line{stroke:var(--bpr-link)}
+.bpr-spark__dot{fill:var(--bpr-link)}
+.bpr-spark figcaption{text-align:center;color:var(--bpr-muted);font-size:.8rem}
+.bpr-cta{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;border-radius:12px;text-decoration:none;border:1px solid var(--bpr-border);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,0));font-weight:700;color:var(--bpr-text)}
+.bpr-cta:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.12)}
+.bpr-cta__label{letter-spacing:.2px}
+.bpr-cta__price{color:var(--bpr-muted)}
+@media (prefers-reduced-motion:reduce){.bpr-cta:hover{transform:none}}
 
 .price-history{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:14px 0}
 .info-icon{display:inline-block;width:14px;height:14px;border-radius:50%;background:var(--info);color:var(--text);font-size:.7rem;line-height:14px;text-align:center;margin-left:4px;cursor:help;font-style:normal;font-weight:700}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -28,8 +28,81 @@
     </ul>
   </header>
 
-  {% if best %}
-  {% set diff = ((min_price - avg7) / avg7 * 100) if (min_price and avg7) else None %}
+{% set price_indicator %}
+<section id="preisindikator" class="bpr-price-indicator" aria-labelledby="preisindikator__title"
+  data-currency="EUR"
+  data-product-name="{{ game.title }}"
+  data-product-url="https://brettspielpreisradar.de/spiel/{{ game.slug }}/"
+  {% if best and best.image_url %}data-product-image="{{ best.image_url }}"{% endif %}
+  {% if min_price is not none %}data-current="{{ '%.2f'|format(min_price) }}"{% endif %}
+  {% if avg7 %}data-seven-day-average="{{ '%.2f'|format(avg7) }}"{% endif %}
+  data-history='{{ history_json | safe }}'
+  {% if best and best.url %}data-offer-url="{{ best.url }}"{% endif %}
+  data-availability="{% if offers %}InStock{% else %}OutOfStock{% endif %}">
+  <div class="bpr-card">
+    <header class="bpr-header">
+      <h2 id="preisindikator__title" class="bpr-title">Preisindikator</h2>
+      <div class="bpr-pill" role="status" aria-live="polite" aria-atomic="true">
+        <span class="bpr-pill__dot" aria-hidden="true"></span>
+        <span class="bpr-pill__label">–</span>
+      </div>
+    </header>
+    <div class="bpr-grid">
+      <div class="bpr-main">
+        <div class="bpr-price">
+          <div class="bpr-price__label">Aktuell</div>
+          <div class="bpr-price__value" data-field="current">– €</div>
+          <div class="bpr-price__delta" data-field="delta">–%</div>
+        </div>
+        <div class="bpr-metrics" role="group" aria-label="Preis-Kennzahlen">
+          <div class="bpr-metric">
+            <div class="bpr-metric__label">Ø 7 Tage</div>
+            <div class="bpr-metric__value" data-field="avg7">– €</div>
+          </div>
+          <div class="bpr-metric">
+            <div class="bpr-metric__label">30-Tage-Tief</div>
+            <div class="bpr-metric__value" data-field="low30">– €</div>
+          </div>
+          <div class="bpr-metric">
+            <div class="bpr-metric__label">30-Tage-Hoch</div>
+            <div class="bpr-metric__value" data-field="high30">– €</div>
+          </div>
+        </div>
+        <div class="bpr-gauge" role="img" aria-label="aktueller Preis relativ zum 30‑Tage‑Spektrum">
+          <div class="bpr-gauge__track" aria-hidden="true"></div>
+          <div class="bpr-gauge__fill" aria-hidden="true"></div>
+          <div class="bpr-gauge__marker" aria-hidden="true"><span>Jetzt</span></div>
+          <div class="bpr-gauge__legend">
+            <span class="bpr-gauge__min" data-field="low30">– €</span>
+            <span class="bpr-gauge__mid">Ø</span>
+            <span class="bpr-gauge__max" data-field="high30">– €</span>
+          </div>
+        </div>
+      </div>
+      <div class="bpr-side">
+        <figure class="bpr-spark">
+          <svg viewBox="0 0 100 40" preserveAspectRatio="none" role="img" aria-label="30‑Tage‑Preisverlauf">
+            <polyline class="bpr-spark__line" points="" fill="none" stroke-width="2" vector-effect="non-scaling-stroke" />
+            <circle class="bpr-spark__dot" cx="0" cy="0" r="2.5" />
+          </svg>
+          <figcaption>Preisverlauf (30 Tage)</figcaption>
+        </figure>
+        {% if best and best.url %}
+        {% set sep = '?' if '?' not in best.url else '&' %}
+        <a class="bpr-cta" href="{{ best.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" rel="nofollow sponsored" data-field="offerUrl">
+          <span class="bpr-cta__label">Zum Angebot</span>
+          <span class="bpr-cta__price" data-field="current">– €</span>
+        </a>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>
+{% endset %}
+
+{% if best %}
+{% set diff = ((min_price - avg7) / avg7 * 100) if (min_price and avg7) else None %}
+<div class="hero-offers">
   <section class="best-price" aria-label="Bestpreis">
     <div class="bp-main">
       <span class="bp-price">{{ '%.2f'|format(best.total_eur or best.price_eur) }}&nbsp;€</span>
@@ -49,27 +122,11 @@
     </div>
     {% endif %}
   </section>
-  {% endif %}
-
-  <section class="price-indicator" role="group" aria-label="Preisindikator">
-    <div class="pi-header">
-      <span class="pi-title">Preisindikator</span>
-      {% set badge_map = {'good':'Gut','ok':'Ok','high':'Teuer'} %}
-      <span class="pi-badge{% if price_trend %} {{ price_trend }}{% endif %}" id="pi-badge" aria-live="polite">{{ badge_map.get(price_trend, '–') }}</span>
-    </div>
-
-    {% set marker_pos = {'good':'16%','ok':'50%','high':'84%'} %}
-    <div class="pi-bar" aria-hidden="true">
-      <div class="pi-marker{% if price_trend %} {{ price_trend }}{% endif %}" id="pi-marker" title="Aktueller Preis" style="left: {{ marker_pos.get(price_trend, '50%') }};"></div>
-    </div>
-
-    <dl class="pi-stats">
-      <div><dt>Aktuell<span class="info-icon" title="Niedrigster Gesamtpreis heute inkl. Versand">ℹ</span></dt><dd id="pi-current">{% if min_price is not none %}{{ '%.2f'|format(min_price) }}&nbsp;€{% else %}–{% endif %}</dd></div>
-      <div><dt>Ø {{ avg_days }} Tage<span class="info-icon" title="Durchschnittlicher Gesamtpreis der letzten {{ avg_days }} Tage">ℹ</span></dt><dd id="pi-avg">{% if avg7 %}{{ '%.2f'|format(avg7) }}&nbsp;€{% else %}–{% endif %}</dd></div>
-    </dl>
-
-    <p class="pi-note">Basis: Tages-Bestpreis inkl. Versand vs. Ø der letzten 7 Tage.</p>
-  </section>
+  {{ price_indicator | safe }}
+</div>
+{% else %}
+  {{ price_indicator | safe }}
+{% endif %}
 
   <section class="offers" id="angebote">
     <div class="offers-head">
@@ -217,11 +274,7 @@
       const data = hist.map(r=>r.min);
       new Chart(ctx,{type:'line',data:{labels:labels,datasets:[{label:'Preis',data:data,borderColor:'#3e95cd',fill:false}]},options:{plugins:{legend:{display:false}},scales:{y:{ticks:{callback:(v)=>v+' €'}}}}});
     }
-    {% if min_price is not none and avg7 is not none %}
-    if (typeof window.renderPI === 'function'){
-      window.renderPI({current: {{ '%.2f'|format(min_price) }}, avg7: {{ '%.2f'|format(avg7) }}} );
-    }
-    {% endif %}
+    
     var moreBtn=document.getElementById('moreOffersBtn');
     if(moreBtn){
       moreBtn.addEventListener('click',function(){
@@ -246,11 +299,84 @@
     }
 
     var priceHistory=document.querySelector('.price-history');
-    var priceIndicator=document.querySelector('.price-indicator');
+    var priceIndicator=document.querySelector('.bpr-price-indicator');
     if(priceHistory && priceIndicator && window.matchMedia('(max-width:719px)').matches){
       priceIndicator.insertAdjacentElement('afterend', priceHistory);
     }
   });
+  </script>
+  <script>
+  (function(){
+    const el=document.querySelector('#preisindikator');
+    if(!el) return;
+    const currency=el.dataset.currency||'EUR';
+    const name=el.dataset.productName||document.querySelector('h1')?.textContent?.trim()||'Produkt';
+    const url=el.dataset.productUrl||location.href;
+    const image=el.dataset.productImage||'';
+    const offerUrl=el.dataset.offerUrl||'#';
+    const availability=el.dataset.availability||'InStock';
+    const cur=Number(el.dataset.current||0);
+    const avg7=Number(el.dataset.sevenDayAverage||0);
+    let history=[];
+    try{history=JSON.parse(el.dataset.history||'[]');}catch(e){history=[];}
+    if(history.length&&typeof history[0]==='object'){history=history.map(h=>h.min);}
+    const nf=new Intl.NumberFormat('de-DE',{style:'currency',currency});
+    const pctf=new Intl.NumberFormat('de-DE',{maximumFractionDigits:1,minimumFractionDigits:1});
+    const low30=history.length?Math.min(...history):Math.min(cur,avg7||cur);
+    const high30=history.length?Math.max(...history):Math.max(cur,avg7||cur);
+    const delta=avg7?((cur-avg7)/avg7):0;
+    let statusLabel='OK';
+    let statusTone='ok';
+    if(delta<=-0.10){statusLabel='Top‑Deal';statusTone='good';}
+    else if(delta<=-0.03){statusLabel='Gut';statusTone='good';}
+    else if(Math.abs(delta)<=0.03){statusLabel='OK';statusTone='ok';}
+    else{statusLabel='Hoch';statusTone='high';}
+    el.querySelectorAll('[data-field="current"]').forEach(n=>n.textContent=nf.format(cur));
+    const avgEl=el.querySelector('[data-field="avg7"]');if(avgEl)avgEl.textContent=nf.format(avg7||cur);
+    el.querySelectorAll('[data-field="low30"]').forEach(n=>n.textContent=nf.format(low30));
+    el.querySelectorAll('[data-field="high30"]').forEach(n=>n.textContent=nf.format(high30));
+    const deltaEl=el.querySelector('[data-field="delta"]');
+    if(deltaEl){const sign=delta>0?'+':'';deltaEl.textContent=`${sign}${pctf.format(delta*100)} vs. 7‑Tage‑Ø`;}
+    const pill=el.querySelector('.bpr-pill');
+    if(pill){
+      const dot=pill.querySelector('.bpr-pill__dot');
+      const lab=pill.querySelector('.bpr-pill__label');
+      if(dot) dot.style.background=statusTone==='good'?'var(--bpr-good)':statusTone==='ok'?'var(--bpr-ok)':'var(--bpr-high)';
+      if(lab) lab.textContent=statusLabel;
+    }
+    const cta=el.querySelector('.bpr-cta');
+    if(cta) cta.href=offerUrl||'#';
+    const gaugeFill=el.querySelector('.bpr-gauge__fill');
+    const gaugeMarker=el.querySelector('.bpr-gauge__marker');
+    const range=Math.max(0.01,high30-low30);
+    const pct=Math.max(0,Math.min(1,(cur-low30)/range));
+    const pctMid=avg7?Math.max(0,Math.min(1,(avg7-low30)/range)):0.5;
+    if(gaugeFill) gaugeFill.style.width=`${pct*100}%`;
+    if(gaugeMarker) gaugeMarker.style.left=`${pct*100}%`;
+    const mid=el.querySelector('.bpr-gauge__mid');
+    if(mid) mid.style.transform=`translateX(${(pctMid*100-50)*.2}%)`;
+    const svg=el.querySelector('.bpr-spark svg');
+    if(svg&&history.length){
+      const w=100,h=40;const min=low30,max=high30;const xStep=w/(history.length-1);
+      const points=history.map((v,i)=>{const x=i*xStep;const y=h-((v-min)/Math.max(0.01,max-min))*h;return `${x.toFixed(2)},${y.toFixed(2)}`;}).join(' ');
+      svg.querySelector('.bpr-spark__line').setAttribute('points',points);
+      const lastX=(history.length-1)*xStep;const lastY=h-((history[history.length-1]-min)/Math.max(0.01,max-min))*h;
+      svg.querySelector('.bpr-spark__dot').setAttribute('cx',lastX);
+      svg.querySelector('.bpr-spark__dot').setAttribute('cy',lastY);
+    }else if(svg){svg.parentElement.style.display='none';}
+    const jsonld={
+      '@context':'https://schema.org',
+      '@type':'Product',
+      name:name,
+      image:image?[image]:undefined,
+      url:url,
+      offers:{'@type':'Offer',url:offerUrl||url,priceCurrency:currency,price:cur.toFixed(2),availability:`https://schema.org/${availability}`}
+    };
+    const s=document.createElement('script');
+    s.type='application/ld+json';
+    s.textContent=JSON.stringify(jsonld);
+    document.head.appendChild(s);
+  })();
   </script>
   <script type="application/ld+json">{{ breadcrumb_json | safe }}</script>
 


### PR DESCRIPTION
## Summary
- Revamp the price indicator with a richer card UI and gauge
- Align best-price box and indicator side-by-side on desktop
- Add dynamic script to compute price metrics and sparkline
- Introduce dedicated dark/light color palette for the price indicator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6665899483218c232d7f5d6714c0