### PR TITLE
Add dark theme support and Amazon price tile

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -39,6 +39,17 @@
   }
 }
 
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#0b0c0f;
+    --panel:#11131a;
+    --card:#11131a;
+    --text:#e9ecf1;
+    --muted:#a3adbd;
+    --border:#222633;
+  }
+}
+
 *{box-sizing:border-box}
 html{font-size:16px}
 @media (min-width:880px){ html{font-size:17px} }
@@ -56,7 +67,8 @@ a:hover{text-decoration:underline}
 .header-inner{display:flex;align-items:center;justify-content:space-between;gap:12px}
 .brand{display:flex;align-items:center;gap:10px;font-weight:700;color:var(--color-primary)}
 .brand-text{font-size:1.05rem}
-.nav-toggle{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border:none;border-radius:10px;background:#fff;color:var(--color-primary);transition:background .3s}
+.nav-toggle{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border:none;border-radius:10px;background:#fff;color:var(--color-primary);transition:background .3s,transform .2s}
+.nav-toggle:active{transform:scale(.9)}
 .nav-toggle .hamburger{display:block;width:20px;height:2px;position:relative;background:var(--color-primary);border-radius:2px;transition:transform .3s}
 .nav-toggle .hamburger::before,.nav-toggle .hamburger::after{content:"";position:absolute;left:0;width:20px;height:2px;background:var(--color-primary);border-radius:2px;transition:transform .3s,opacity .3s}
 .nav-toggle .hamburger::before{top:-6px}
@@ -66,7 +78,8 @@ a:hover{text-decoration:underline}
 .nav-toggle.open .hamburger::after{opacity:0}
 .main-nav{max-height:0;overflow:hidden;opacity:0;transition:max-height .3s ease,opacity .3s ease;display:block;pointer-events:none;position:absolute;left:0;right:0;top:56px}
 .main-nav.open{max-height:300px;opacity:1;background:var(--color-primary);box-shadow:var(--shadow);z-index:50;pointer-events:auto}
-.main-nav a{display:block;padding:12px 16px;color:#0f172a}
+.main-nav a{display:block;padding:12px 16px;color:#0f172a;transition:background .3s,transform .2s}
+.main-nav a:active{transform:scale(.97)}
 .main-nav.open a{color:#fff;border-top:1px solid rgba(255,255,255,.15)}
 .main-nav.open a:first-child{border-top:none}
 @media (min-width:720px){
@@ -84,15 +97,15 @@ a:hover{text-decoration:underline}
 .chip{background:#eef2ff;border:1px solid var(--border);border-radius:999px;padding:6px 10px;font-size:.9rem}
 
 .h2{font-size:1.25rem;margin:18px 0 10px}
-.content-section{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:14px;margin:14px 0}
+.content-section{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:14px;margin:14px 0;box-shadow:var(--shadow)}
 
 /* Best Price Box */
-.best-price{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:14px 0;display:flex;flex-direction:column;gap:8px}
+.best-price{border:1px solid var(--pi-ring);border-radius:14px;padding:14px;background:#fff;margin:14px 0;display:flex;flex-direction:column;gap:8px;box-shadow:var(--shadow)}
 .bp-main{display:flex;flex-direction:column;gap:4px}
 .bp-price{font-size:1.6rem;font-weight:700}
 .bp-shop{font-size:1rem;font-weight:600}
 .bp-time{font-size:.85rem;color:var(--muted)}
-.bp-img{width:100%;aspect-ratio:4/3;object-fit:contain;border-radius:10px;border:1px solid var(--border);margin:8px 0;background:#fff}
+.bp-img{width:100%;aspect-ratio:4/3;object-fit:contain;border-radius:10px;border:1px solid var(--border);margin:8px 0;background:#fff;display:block}
 .bp-indicator{margin:0;font-size:.95rem}
 .bp-badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:4px}
 
@@ -130,11 +143,6 @@ a:hover{text-decoration:underline}
 .bpr-gauge__marker{position:absolute;top:8px;transform:translate(-50%,-50%);background:var(--bpr-card);border:1px solid var(--bpr-border);padding:2px 6px;border-radius:8px;font-size:.75rem;white-space:nowrap}
 .bpr-gauge__legend{display:flex;justify-content:space-between;margin-top:8px;font-size:.8rem;color:var(--bpr-muted)}
 .bpr-side{display:grid;gap:14px;align-content:start}
-.bpr-spark{display:grid;gap:8px}
-.bpr-spark svg{width:100%;height:120px;background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,0));border:1px solid var(--bpr-border);border-radius:12px;padding:8px}
-.bpr-spark__line{stroke:var(--bpr-link)}
-.bpr-spark__dot{fill:var(--bpr-link)}
-.bpr-spark figcaption{text-align:center;color:var(--bpr-muted);font-size:.8rem}
 .bpr-cta{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;border-radius:12px;text-decoration:none;border:1px solid var(--bpr-border);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,0));font-weight:700;color:var(--bpr-text)}
 .bpr-cta:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.12)}
 .bpr-cta__label{letter-spacing:.2px}
@@ -145,10 +153,12 @@ a:hover{text-decoration:underline}
 .info-icon{display:inline-block;width:14px;height:14px;border-radius:50%;background:var(--info);color:var(--text);font-size:.7rem;line-height:14px;text-align:center;margin-left:4px;cursor:help;font-style:normal;font-weight:700}
 
 .cta-row{margin-top:8px}
-.btn{display:inline-flex;align-items:center;justify-content:center;border-radius:12px;border:1px solid transparent;padding:12px 14px;font-weight:700;min-height:44px}
+.amazon-tile{text-align:center}
+.btn{display:inline-flex;align-items:center;justify-content:center;border-radius:12px;border:1px solid transparent;padding:12px 14px;font-weight:700;min-height:44px;transition:background .3s,transform .15s}
 .btn-sm{min-height:36px;padding:8px 10px;font-size:.9rem}
 .btn-primary{background:var(--color-primary);color:white;width:100%}
 .btn-primary:hover{opacity:.92;text-decoration:none}
+.btn:active{transform:scale(.97)}
 .btn-secondary{background:var(--color-secondary);color:white;width:100%}
 .btn-secondary:hover{opacity:.95}
 .btn-link{color:var(--color-primary)}
@@ -164,7 +174,7 @@ a:hover{text-decoration:underline}
 @media (max-width:480px){ .filters label{flex:1 1 100%} }
 .game-list{list-style:none;padding:0;margin:0}
 .game-list li{margin:6px 0}
-.game-list a{display:block;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);color:var(--text);text-decoration:none}
+.game-list a{display:block;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);color:var(--text);text-decoration:none;box-shadow:var(--shadow)}
 .game-list a:hover{background:#f8fafc}
 @media (min-width:720px){ .btn-primary,.btn-secondary{width:auto} }
 
@@ -214,6 +224,8 @@ a:hover{text-decoration:underline}
 .row--best .btn{background:var(--color-secondary);color:#fff}
 .price-table tbody tr:hover{background:var(--panel)}
 .btn-cta{white-space:nowrap}
+.offer-main{display:flex;align-items:center;gap:10px}
+.offer-img{width:64px;height:64px;object-fit:contain;border:1px solid var(--border);border-radius:8px;background:#fff;flex-shrink:0}
 .disclaimer{color:var(--muted);font-size:.9rem;margin:.75rem .25rem 0}
 
 @media (max-width:840px){
@@ -234,7 +246,7 @@ a:hover{text-decoration:underline}
   .price-history .price-chart{max-width:600px;margin-left:auto;margin-right:auto}
 }
 
-.faq details{border:1px solid var(--border);border-radius:10px;margin:8px 0;background:#f8fafc}
+.faq details{border:1px solid var(--border);border-radius:10px;margin:8px 0;background:#f8fafc;box-shadow:var(--shadow)}
 .faq summary{cursor:pointer;padding:12px 14px;font-weight:700;min-height:44px;display:flex;align-items:center}
 .faq .answer{padding:0 14px 12px}
 

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -80,13 +80,6 @@
         </div>
       </div>
       <div class="bpr-side">
-        <figure class="bpr-spark">
-          <svg viewBox="0 0 100 40" preserveAspectRatio="none" role="img" aria-label="30‑Tage‑Preisverlauf">
-            <polyline class="bpr-spark__line" points="" fill="none" stroke-width="2" vector-effect="non-scaling-stroke" />
-            <circle class="bpr-spark__dot" cx="0" cy="0" r="2.5" />
-          </svg>
-          <figcaption>Preisverlauf (30 Tage)</figcaption>
-        </figure>
         {% if best and best.url %}
         {% set sep = '?' if '?' not in best.url else '&' %}
         <a class="bpr-cta" href="{{ best.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" rel="nofollow sponsored" data-field="offerUrl">
@@ -150,8 +143,13 @@
           {% set sep = '?' if '?' not in o.url else '&' %}
           <tr class="offer-row{% if loop.first %} row--best{% endif %}{% if extra %} extra{% endif %}" {% if extra %}style="display:none"{% endif %} data-offer>
             <td class="cell cell--title">
-              <a class="title" href="{{ o.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a>
-              {% if loop.first %}<span class="badge badge--best">Bestpreis</span>{% endif %}
+              <div class="offer-main">
+                {% if o.image_url %}<img class="offer-img" src="{{ o.image_url }}" alt="" loading="lazy">{% endif %}
+                <div>
+                  <a class="title" href="{{ o.url ~ sep ~ 'utm_source=bpr&utm_medium=offer&utm_campaign=' ~ game.slug }}" target="_blank" rel="nofollow sponsored noopener">{{ o.title }}</a>
+                  {% if loop.first %}<span class="badge badge--best">Bestpreis</span>{% endif %}
+                </div>
+              </div>
             </td>
             <td class="cell cell--price">
               <span class="price">{% if o.total_eur is number %}{{ '%.2f'|format(o.total_eur) }}&nbsp;€{% else %}–{% endif %}</span>
@@ -172,9 +170,9 @@
       <p class="muted">Gerade keine passenden Angebote. Schau später wieder vorbei – die Seite aktualisiert sich regelmäßig.</p>
     {% endif %}
     {% if amazon_search_url %}
-    <div class="cta-row">
+    <section class="content-section amazon-tile">
       <a class="btn btn-secondary" href="{{ amazon_search_url }}" target="_blank" rel="nofollow sponsored noopener">Preis auf Amazon prüfen</a>
-    </div>
+    </section>
     {% endif %}
   </section>
 
@@ -355,15 +353,6 @@
     if(gaugeMarker) gaugeMarker.style.left=`${pct*100}%`;
     const mid=el.querySelector('.bpr-gauge__mid');
     if(mid) mid.style.transform=`translateX(${(pctMid*100-50)*.2}%)`;
-    const svg=el.querySelector('.bpr-spark svg');
-    if(svg&&history.length){
-      const w=100,h=40;const min=low30,max=high30;const xStep=w/(history.length-1);
-      const points=history.map((v,i)=>{const x=i*xStep;const y=h-((v-min)/Math.max(0.01,max-min))*h;return `${x.toFixed(2)},${y.toFixed(2)}`;}).join(' ');
-      svg.querySelector('.bpr-spark__line').setAttribute('points',points);
-      const lastX=(history.length-1)*xStep;const lastY=h-((history[history.length-1]-min)/Math.max(0.01,max-min))*h;
-      svg.querySelector('.bpr-spark__dot').setAttribute('cx',lastX);
-      svg.querySelector('.bpr-spark__dot').setAttribute('cy',lastY);
-    }else if(svg){svg.parentElement.style.display='none';}
     const jsonld={
       '@context':'https://schema.org',
       '@type':'Product',


### PR DESCRIPTION
## Summary
- implement dark theme variables for whole site while keeping light default
- add button and navigation animations for more interactive feel
- turn Amazon price check into standalone tile for consistent layout
- show offer thumbnails in comparison table
- remove price history sparkline from price indicator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6fd142a08321b53dde97c19d3341