### PR TITLE
feat: support automatic light and dark theme

### DIFF
--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<!-- ui-version:2025-08-11-v9 -->
+<!-- ui-version:2025-08-23-v15 -->
 <!-- Test-Preview -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Datenschutz – Brettspiel Preisradar</title>
-  <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-11-v9" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v9">
+  <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b0c0f" media="(prefers-color-scheme: dark)">
+  <link rel="preload" href="/styles.css?v=2025-08-23-v15" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v15">
   <script>
     function loadAnalytics(){
       if(window.gaLoaded) return;
@@ -138,7 +140,7 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-11-v9" defer></script>
+  <script src="/main.js?v=2025-08-23-v15" defer></script>
 </body>
 </html>
 

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -1,13 +1,15 @@
 <!doctype html>
-<!-- ui-version:2025-08-11-v9 -->
+<!-- ui-version:2025-08-23-v15 -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Impressum – Brettspiel Preisradar</title>
-  <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-11-v9" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v9">
+  <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b0c0f" media="(prefers-color-scheme: dark)">
+  <link rel="preload" href="/styles.css?v=2025-08-23-v15" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v15">
   <script>
     function loadAnalytics(){
       if(window.gaLoaded) return;
@@ -77,7 +79,7 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-11-v9" defer></script>
+  <script src="/main.js?v=2025-08-23-v15" defer></script>
 </body>
 </html>
 

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,5 @@
 
-// ui-version:2025-08-23-v13 – Menü-Overlay, Preisindikator ohne Graph, Suche & Cookie-Banner unten
+// ui-version:2025-08-23-v15 – Menü-Overlay, Preisindikator ohne Graph, Suche & Cookie-Banner unten
 (function(){
   // Menü
   var btn = document.getElementById('nav-toggle');

--- a/public/neuigkeiten.html
+++ b/public/neuigkeiten.html
@@ -1,13 +1,15 @@
 <!doctype html>
-<!-- ui-version:2025-08-11-v9 -->
+<!-- ui-version:2025-08-23-v15 -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Neuigkeiten – Brettspiel Preisradar</title>
-  <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-11-v9" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-11-v9">
+  <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b0c0f" media="(prefers-color-scheme: dark)">
+  <link rel="preload" href="/styles.css?v=2025-08-23-v15" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v15">
   <script>
     function loadAnalytics(){
       if(window.gaLoaded) return;
@@ -72,6 +74,6 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-11-v9" defer></script>
+  <script src="/main.js?v=2025-08-23-v15" defer></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-/* ui-version:2025-08-23-v14 – Kompaktere Bestpreis-Box & hübschere Tabelle */
+/* ui-version:2025-08-23-v15 – Automatische helle/dunkle Themes */
 :root{
   --color-primary:#ff7f11;
   --color-secondary:#ff9f1c;
@@ -17,26 +17,15 @@
   --badge:#334155;
   --badge-text:#e2e8f0;
   --pi-ring:rgba(0,0,0,.08);
-  --bpr-bg:#0b0c0f;
-  --bpr-card:#11131a;
-  --bpr-text:#e9ecf1;
-  --bpr-muted:#a3adbd;
-  --bpr-border:#222633;
+  --bpr-bg:#ffffff;
+  --bpr-card:#f8fafc;
+  --bpr-text:#0f172a;
+  --bpr-muted:#475569;
+  --bpr-border:#e2e8f0;
   --bpr-good:#22c55e;
   --bpr-ok:#eab308;
   --bpr-high:#ef4444;
-  --bpr-link:#60a5fa;
-}
-
-@media (prefers-color-scheme:light){
-  :root{
-    --bpr-bg:#ffffff;
-    --bpr-card:#f8fafc;
-    --bpr-text:#0f172a;
-    --bpr-muted:#475569;
-    --bpr-border:#e2e8f0;
-    --bpr-link:#2563eb;
-  }
+  --bpr-link:#2563eb;
 }
 
 @media (prefers-color-scheme:dark){
@@ -47,6 +36,12 @@
     --text:#e9ecf1;
     --muted:#a3adbd;
     --border:#222633;
+    --bpr-bg:#0b0c0f;
+    --bpr-card:#11131a;
+    --bpr-text:#e9ecf1;
+    --bpr-muted:#a3adbd;
+    --bpr-border:#222633;
+    --bpr-link:#60a5fa;
   }
 }
 

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -1,14 +1,16 @@
 <!doctype html>
-<!-- ui-version:2025-08-23-v13 -->
+<!-- ui-version:2025-08-23-v15 -->
 <html lang="de">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar</title>
   {% if meta_description %}<meta name="description" content="{{ meta_description|e }}">{% endif %}
-  <meta name="theme-color" content="#ffffff">
-  <link rel="preload" href="/styles.css?v=2025-08-23-v13" as="style">
-  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v13">
+  <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b0c0f" media="(prefers-color-scheme: dark)">
+  <link rel="preload" href="/styles.css?v=2025-08-23-v15" as="style">
+  <link rel="stylesheet" href="/styles.css?v=2025-08-23-v15">
   {% if canonical %}<link rel="canonical" href="{{ canonical }}">{% endif %}
   <meta property="og:type" content="website">
   <meta property="og:title" content="{% if title %}{{ title }} – {% endif %}Brettspiel Preisradar">
@@ -79,7 +81,7 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=2025-08-23-v13" defer></script>
+  <script src="/main.js?v=2025-08-23-v15" defer></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- enable automatic switching between light and dark mode via CSS variables
- expose color-scheme and theme-color metadata for both modes
- update static pages to reference new assets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd0e11fe88321b327f911ce05be1c