### PR TITLE
Fix inconsistent separators in offer tiles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -201,10 +201,9 @@ a:hover{text-decoration:underline}
   font-weight:700;
   letter-spacing:.2px;
   background:var(--panel);
-  border-bottom:1px solid var(--border);
   position:sticky;top:0;z-index:1;
 }
-.price-table tbody tr + tr td{border-top:1px solid var(--border)}
+.price-table tbody tr td{border-top:1px solid var(--border)}
 .cell{padding:1rem 1.25rem;vertical-align:middle}
 .cell--title{width:46%}
 .cell--price{width:14%;white-space:nowrap}
@@ -231,7 +230,7 @@ a:hover{text-decoration:underline}
 @media (max-width:840px){
   .price-table thead{display:none}
   .price-table,.price-table tbody,.price-table tr,.price-table td{display:block;width:100%}
-  .price-table tbody tr{border-top:1px solid var(--border);padding:.9rem}
+  .price-table tbody tr{padding:.9rem}
   .cell{padding:.35rem 0}
   .cell--title{padding-top:.2rem}
   .cell--cta{padding-top:.6rem;text-align:left}


### PR DESCRIPTION
## Summary
- Ensure all offer tiles in the price table show horizontal separators for each row
- Simplify mobile styling to rely on cell borders for consistent separation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd194ae648321ad196393b9fbd16a