### PR TITLE
Restrict eBay search links to board game category

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -25,6 +25,22 @@ EPN_CAMPAIGN_ID = os.getenv("EPN_CAMPAIGN_ID", "").strip()
 EPN_REFERENCE_ID = os.getenv("EPN_REFERENCE_ID", "preisradar").strip()
 AMAZON_PARTNER_ID = os.getenv("AMAZON_PARTNER_ID", "28310edf-21").strip()
 
+# Load default filters (e.g. eBay category) from config
+FILTER_PATH = ROOT / "config" / "filters.yaml"
+
+
+def load_filter_config(path):
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    return {}
+
+
+FILTER_CFG = load_filter_config(FILTER_PATH)
+DEFAULT_EBAY_CATEGORY_ID = str(
+    FILTER_CFG.get("default_ebay_category_id", "180349")
+).strip()
+
 # Fenstergröße für Preisindikator (Tage)
 AVG_WINDOW_DAYS = 7
 
@@ -192,7 +208,12 @@ def build_epn_search_url(game):
         q = queries[0]
     else:
         q = game.get("slug") or ""
+    cat = str(game.get("ebay_category_id") or "").strip()
+    if not cat:
+        cat = DEFAULT_EBAY_CATEGORY_ID
     url = f"https://www.ebay.de/sch/i.html?_nkw={quote_plus(q)}"
+    if cat:
+        url += f"&_sacat={cat}"
     if EPN_CAMPAIGN_ID:
         url += f"&campid={EPN_CAMPAIGN_ID}&customid={EPN_REFERENCE_ID}-{game.get('slug','')}"
     return url

--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -270,6 +270,8 @@ def fetch_for_game(game: Dict[str, Any], max_keep: int = 100) -> List[Dict[str, 
             aspect_filters=aspect_filters,
         )
         search_url = f"https://www.ebay.de/sch/i.html?_nkw={quote_plus(q)}"
+        if category_id:
+            search_url += f"&_sacat={category_id}"
         for it in items:
             iid = it.get("itemId")
             if not iid or iid in seen:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3,10 +3,16 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.build import is_relevant
+from scripts.build import is_relevant, build_epn_search_url, DEFAULT_EBAY_CATEGORY_ID
 
 
 def test_is_relevant_respects_negative_label():
     offer = {"itemId": "1", "title": "foo"}
     labels = {"1": False}
     assert is_relevant(offer, labels) is False
+
+
+def test_build_epn_search_url_adds_category():
+    game = {"slug": "catan", "search_terms": ["Catan"]}
+    url = build_epn_search_url(game)
+    assert f"_sacat={DEFAULT_EBAY_CATEGORY_ID}" in url

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -143,3 +143,22 @@ def test_fetch_for_game_filters_game_specific_keywords():
         ]
         offers = mod.fetch_for_game(game)
         assert offers == []
+
+
+def test_fetch_for_game_includes_category_in_search_url():
+    mod = load_module()
+    game = {"slug": "catan", "search_terms": ["Catan"]}
+    with patch("scripts.fetch_offers_ebay_enhanced.search_once") as mock_search:
+        mock_search.return_value = [
+            {
+                "itemId": "1",
+                "title": "Catan",
+                "categoryId": mod.DEFAULT_CATEGORY_ID,
+                "price": {"currency": "EUR", "value": "10"},
+                "conditionId": "1000",
+                "seller": {"username": "other", "accountType": "BUSINESS"},
+                "itemWebUrl": "http://example.com",
+            }
+        ]
+        offers = mod.fetch_for_game(game)
+        assert offers and f"_sacat={mod.DEFAULT_CATEGORY_ID}" in offers[0]["search_url"]


### PR DESCRIPTION
## Summary
- Load default filters including board game category from `config/filters.yaml`
- Append `_sacat` parameter to eBay search URLs to limit results to board games
- Cover new category filtering in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd21651cc8321bec12eee87d30a27