### PR TITLE
Expand eBay filter with additional negative keywords

### DIFF
--- a/config/filters.yaml
+++ b/config/filters.yaml
@@ -2,11 +2,33 @@
 # from the price statistics (case-insensitive).
 exclude_terms:
   - erweiterung
+  - erweiterungen
+  - erweiterungspack
+  - erweiterungsset
+  - erweiterungsbox
   - expansion
+  - expansions
+  - "expansion pack"
+  - "expansion set"
+  - addon
+  - add-on
+  - dlc
   - insert
   - organizer
   - sleeve
   - sleeves
+  - hülle
+  - hüllen
+  - huelle
+  - huellen
+  - schutzhülle
+  - schutzhüllen
+  - schutzhuelle
+  - schutzhuellen
+  - case
+  - cover
+  - "box protector"
+  - boxprotector
   - einsatz
   - ersatzteil
   - ersatzteile
@@ -21,6 +43,29 @@ exclude_terms:
   - storage
   - standee
   - minis
+  # Video game platforms and console-related terms
+  - ps4
+  - ps5
+  - ps3
+  - playstation
+  - xbox
+  - nintendo
+  - switch
+  - pc
+  - konsole
+  - controller
+  - digital
+  - download
+  # Additional accessory-related terms
+  - token
+  - tokens
+  - dice
+  - "dice tower"
+  - würfelbecher
+  - würfelturm
+  - "dice tray"
+  - kartenhalter
+  - "card holder"
 
 # eBay condition IDs that count as "new" and are stored in the statistics.
 # 1000 = New, 1500 = New other, 1750 = New with defects

--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -149,8 +149,6 @@ def search_once(
         f"sellerAccountTypes:{{{SELLER_ACCOUNT_TYPE}}}",  # enforce business sellers
         "buyingOptions:{FIXED_PRICE}",  # exclude auctions
     ]
-    if category_id:
-        filters.append(f"categoryIds:{category_id}")
     if min_price is not None:
         filters.append(f"price:[{min_price}..]")
     if ITEM_LOCATION_COUNTRIES:
@@ -164,6 +162,8 @@ def search_once(
         "fieldgroups": "EXTENDED",
         "filter": ",".join(filters),
     }
+    if category_id:
+        params["category_ids"] = str(category_id)
     if aspect_filters:
         af = build_aspect_filter(aspect_filters)
         if af:

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -49,10 +49,11 @@ def test_search_once_adds_filters():
         _, kwargs = mock_get.call_args
         assert "filter" in kwargs["params"]
         flt = kwargs["params"]["filter"]
-        assert "categoryIds:180349" in flt
+        assert "categoryIds" not in flt
         assert "price:[20..]" in flt
         assert "buyingOptions:{FIXED_PRICE}" in flt
         assert "itemLocationCountry:{DE}" in flt
+        assert kwargs["params"].get("category_ids") == "180349"
         assert kwargs["params"].get("aspect_filter") == "Produktart:Eigenständiges Spiel"
 
 


### PR DESCRIPTION
## Summary
- broaden general eBay filter with expansion, case, and download-related exclusion terms
- use dedicated `category_ids` param so eBay searches respect the board-game category

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd46752408321a6b86590345ed453