### PR TITLE
Ensure eBay fetcher discards results without category match

### DIFF
--- a/scripts/fetch_offers_ebay_enhanced.py
+++ b/scripts/fetch_offers_ebay_enhanced.py
@@ -276,8 +276,20 @@ def fetch_for_game(game: Dict[str, Any], max_keep: int = 100) -> List[Dict[str, 
             iid = it.get("itemId")
             if not iid or iid in seen:
                 continue
-            cat_id_item = str(it.get("categoryId") or "")
-            if category_id and cat_id_item and cat_id_item != category_id:
+            # Collect all category IDs reported for the item. If none match the
+            # requested category, the result is ignored. This also discards
+            # items that do not expose any category information at all.
+            item_cats = set()
+            cat_id_item = it.get("categoryId")
+            if cat_id_item is not None:
+                cat_id_item = str(cat_id_item).strip()
+                if cat_id_item:
+                    item_cats.add(cat_id_item)
+            for cat in it.get("categories", []):
+                cid = str(cat.get("categoryId") or "").strip()
+                if cid:
+                    item_cats.add(cid)
+            if category_id and category_id not in item_cats:
                 continue
             price = pick_price_eur(it)
             if price is None or price <= 0:

--- a/tests/test_fetch_offers_ebay_enhanced.py
+++ b/tests/test_fetch_offers_ebay_enhanced.py
@@ -65,6 +65,7 @@ def test_fetch_for_game_returns_business_sellers():
             {
                 "itemId": "1",
                 "title": "Catan",
+                "categoryId": mod.DEFAULT_CATEGORY_ID,
                 "price": {"currency": "EUR", "value": "10"},
                 "conditionId": "1000",
                 "seller": {"username": "other", "accountType": "BUSINESS"},
@@ -105,6 +106,27 @@ def test_fetch_for_game_filters_wrong_category():
                 "itemId": "1",
                 "title": "Catan",
                 "categoryId": "123",
+                "price": {"currency": "EUR", "value": "10"},
+                "conditionId": "1000",
+                "seller": {"username": "other", "accountType": "BUSINESS"},
+                "itemWebUrl": "http://example.com",
+            }
+        ]
+        offers = mod.fetch_for_game(game)
+        assert offers == []
+
+
+def test_fetch_for_game_filters_without_category_id():
+    """Items lacking the expected category must be discarded."""
+    mod = load_module()
+    game = {"slug": "catan", "search_terms": ["Catan"], "ebay_category_id": "180349"}
+    with patch("scripts.fetch_offers_ebay_enhanced.search_once") as mock_search:
+        mock_search.return_value = [
+            {
+                "itemId": "1",
+                "title": "Catan",
+                # no direct categoryId, and categories list without the wanted ID
+                "categories": [{"categoryId": "123"}],
                 "price": {"currency": "EUR", "value": "10"},
                 "conditionId": "1000",
                 "seller": {"username": "other", "accountType": "BUSINESS"},


### PR DESCRIPTION
## Summary
- Check all category IDs returned for an item and drop listings that don't expose the expected category
- Test that items missing the correct category are ignored and adjust existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd55c31c48321b5894229ed411e57