### PR TITLE
Fix frontend price indicator calculations

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -110,6 +110,177 @@
     consentDecline();
     showStatus('Einstellungen gespeichert.');
   });
+
+  var currencyFormatter;
+  try {
+    currencyFormatter = new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency: 'EUR',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
+  } catch (err) {
+    currencyFormatter = null;
+  }
+
+  function isFiniteNumber(value){
+    return typeof value === 'number' && isFinite(value);
+  }
+
+  function parseNumber(value){
+    if (value === undefined || value === null || value === '') return null;
+    if (typeof value === 'number') return isFiniteNumber(value) ? value : null;
+    var num = parseFloat(value);
+    return isFinite(num) ? num : null;
+  }
+
+  function formatCurrency(value){
+    if (!isFiniteNumber(value)) return null;
+    if (currencyFormatter) return currencyFormatter.format(value);
+    return value.toFixed(2).replace('.', ',') + ' €';
+  }
+
+  function formatDelta(value){
+    if (!isFiniteNumber(value)) return null;
+    var abs = Math.abs(value);
+    var formatted = abs < 10 ? value.toFixed(1) : value.toFixed(0);
+    var prefix = value > 0 ? '+' : '';
+    return prefix + formatted.replace('.', ',') + '% vs. 7-Tage-Ø';
+  }
+
+  function updatePriceIndicators(){
+    var indicators = document.querySelectorAll('.bpr-price-indicator');
+    if (!indicators.length) return;
+
+    Array.prototype.forEach.call(indicators, function(el){
+      var dataset = el.dataset || {};
+      var current = parseNumber(dataset.current);
+      var avg7 = parseNumber(dataset.sevenDayAverage);
+      var historyValues = [];
+
+      if (dataset.history){
+        try {
+          var parsed = JSON.parse(dataset.history);
+          if (Array.isArray(parsed)){
+            parsed.forEach(function(entry){
+              if (!entry) return;
+              var val = parseNumber(entry.min !== undefined ? entry.min : entry.avg);
+              if (val !== null) historyValues.push(val);
+            });
+          }
+        } catch (err) {
+          // ignore invalid history payloads
+        }
+      }
+
+      if (!historyValues.length && current !== null){
+        historyValues.push(current);
+      }
+
+      var low = historyValues.length ? Math.min.apply(null, historyValues) : null;
+      var high = historyValues.length ? Math.max.apply(null, historyValues) : null;
+
+      if (current !== null){
+        var currentField = el.querySelector('[data-field="current"]');
+        var formattedCurrent = formatCurrency(current);
+        if (currentField && formattedCurrent) currentField.textContent = formattedCurrent;
+      }
+
+      if (avg7 !== null){
+        var avg7Field = el.querySelector('[data-field="avg7"]');
+        var formattedAvg = formatCurrency(avg7);
+        if (avg7Field && formattedAvg) avg7Field.textContent = formattedAvg;
+      }
+
+      if (low !== null){
+        var formattedLow = formatCurrency(low);
+        if (formattedLow){
+          el.querySelectorAll('[data-field="low30"]').forEach(function(node){
+            node.textContent = formattedLow;
+          });
+        }
+      }
+
+      if (high !== null){
+        var formattedHigh = formatCurrency(high);
+        if (formattedHigh){
+          el.querySelectorAll('[data-field="high30"]').forEach(function(node){
+            node.textContent = formattedHigh;
+          });
+        }
+      }
+
+      var deltaField = el.querySelector('[data-field="delta"]');
+      if (deltaField){
+        if (current !== null && avg7 !== null && avg7 !== 0){
+          var delta = ((current - avg7) / avg7) * 100;
+          var deltaText = formatDelta(delta);
+          if (deltaText){
+            deltaField.textContent = deltaText;
+            deltaField.setAttribute('data-delta', delta.toFixed(2));
+          } else {
+            deltaField.textContent = '–';
+            deltaField.removeAttribute('data-delta');
+          }
+        } else {
+          deltaField.textContent = '–';
+          deltaField.removeAttribute('data-delta');
+        }
+      }
+
+      var marker = el.querySelector('.bpr-gauge__marker');
+      var fill = el.querySelector('.bpr-gauge__fill');
+      if (marker || fill){
+        if (current !== null && low !== null && high !== null){
+          var range = high - low;
+          var pos = range <= 0 ? 0.5 : (current - low) / range;
+          pos = Math.min(1, Math.max(0, pos));
+          var percent = (pos * 100) + '%';
+          if (fill) fill.style.width = percent;
+          if (marker){
+            marker.style.left = percent;
+            marker.setAttribute('aria-label', 'Preisposition ' + Math.round(pos * 100) + '% zwischen Tief und Hoch');
+          }
+        } else {
+          if (fill) fill.style.width = '0%';
+          if (marker){
+            marker.style.left = '0%';
+            marker.removeAttribute('aria-label');
+          }
+        }
+      }
+
+      var trend = dataset.trend;
+      if (!trend || trend === 'null' || trend === 'undefined'){
+        if (current !== null && avg7 !== null && avg7 > 0){
+          var ratio = current / avg7;
+          if (ratio <= 0.95){
+            trend = 'good';
+          } else if (ratio <= 1.05){
+            trend = 'ok';
+          } else {
+            trend = 'high';
+          }
+        } else {
+          trend = null;
+        }
+      }
+
+      var pillLabel = el.querySelector('.bpr-pill__label');
+      if (trend){
+        el.dataset.trend = trend;
+        if (pillLabel){
+          var labelMap = {good: 'Guter Preis', ok: 'Fairer Preis', high: 'Teuer'};
+          pillLabel.textContent = labelMap[trend] || 'Preis';
+        }
+      } else {
+        delete el.dataset.trend;
+        if (pillLabel) pillLabel.textContent = '–';
+      }
+    });
+  }
+
+  updatePriceIndicators();
 })();
 
 function click_offer(merchant, slug, price){

--- a/public/styles.css
+++ b/public/styles.css
@@ -126,12 +126,21 @@ a:hover{text-decoration:underline}
 .bpr-pill{display:inline-flex;gap:.5rem;align-items:center;border:1px solid var(--bpr-border);border-radius:999px;padding:6px 10px;font-weight:600;font-size:.9rem;background:rgba(255,255,255,.03)}
 .bpr-pill__dot{width:10px;height:10px;border-radius:999px;background:var(--bpr-ok);box-shadow:0 0 0 4px rgba(0,0,0,.05) inset}
 .bpr-pill__label{color:var(--bpr-muted)}
+.bpr-price-indicator[data-trend=good] .bpr-pill__dot{background:var(--bpr-good)}
+.bpr-price-indicator[data-trend=ok] .bpr-pill__dot{background:var(--bpr-ok)}
+.bpr-price-indicator[data-trend=high] .bpr-pill__dot{background:var(--bpr-high)}
+.bpr-price-indicator[data-trend=good] .bpr-pill__label{color:var(--bpr-good)}
+.bpr-price-indicator[data-trend=ok] .bpr-pill__label{color:var(--bpr-ok)}
+.bpr-price-indicator[data-trend=high] .bpr-pill__label{color:var(--bpr-high)}
 .bpr-grid{display:grid;gap:18px}
 @media (min-width:880px){.bpr-grid{grid-template-columns:1fr;gap:24px}}
 .bpr-price{display:grid;grid-template-columns:auto 1fr;grid-template-areas:'label value' 'delta delta';align-items:end;column-gap:12px}
 .bpr-price__label{grid-area:label;color:var(--bpr-muted);font-weight:600}
 .bpr-price__value{grid-area:value;font-size:clamp(28px,5vw,40px);font-weight:800;letter-spacing:.2px}
 .bpr-price__delta{grid-area:delta;color:var(--bpr-muted);font-weight:600;margin-top:4px}
+.bpr-price-indicator[data-trend=good] .bpr-price__delta{color:var(--bpr-good)}
+.bpr-price-indicator[data-trend=ok] .bpr-price__delta{color:var(--bpr-ok)}
+.bpr-price-indicator[data-trend=high] .bpr-price__delta{color:var(--bpr-high)}
 .bpr-metrics{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:14px}
 .bpr-metric{border:1px dashed var(--bpr-border);border-radius:12px;padding:10px 12px}
 .bpr-metric__label{color:var(--bpr-muted);font-size:.82rem}

--- a/templates/page.html.jinja
+++ b/templates/page.html.jinja
@@ -36,6 +36,7 @@
   {% if best and best.image_url %}data-product-image="{{ best.image_url }}"{% endif %}
   {% if min_price is not none %}data-current="{{ '%.2f'|format(min_price) }}"{% endif %}
   {% if avg7 %}data-seven-day-average="{{ '%.2f'|format(avg7) }}"{% endif %}
+  {% if price_trend %}data-trend="{{ price_trend }}"{% endif %}
   data-history='{{ history_json | safe }}'
   {% if best and best.url %}data-offer-url="{{ best.url }}"{% endif %}
   data-availability="{% if offers %}InStock{% else %}OutOfStock{% endif %}">


### PR DESCRIPTION
## Summary
- compute and render price indicator metrics on the client based on embedded history data
- color pill status and delta text according to the computed price trend
- expose the backend trend value via a data attribute for the indicator widget

## Testing
- pytest tests/test_build.py

------
https://chatgpt.com/codex/tasks/task_e_68e91f6c2d888321aaddf2211b41c336